### PR TITLE
Implement a simple CLI for parser

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,64 @@
+[metadata]
+name = opera-tosca-parser
+url = https://github.com/xlab-si/xopera-tosca-parser
+project_urls =
+    Documentation = https://xlab-si.github.io/xopera-docs/
+    Source Code = https://github.com/xlab-si/xopera-tosca-parser
+    Bug Tracker = https://github.com/xlab-si/xopera-tosca-parser/issues
+    Discussions = https://github.com/xlab-si/xopera-tosca-parser/discussions
+    Releases = https://github.com/xlab-si/xopera-tosca-parser/releases
+    Pre-releases = https://test.pypi.org/project/opera-tosca-parser/#history
+    Examples = https://github.com/xlab-si/xopera-examples
+    CI = https://github.com/xlab-si/xopera-tosca-parser/actions/
+author = XLAB d.o.o.
+author_email = pypi@xlab.si
+maintainer = xOpera team
+maintainer_email = xopera@xlab.si
+license_file = LICENSE
+description = xOpera TOSCA parser
+long_description = file: README.md
+long_description_content_type = text/markdown
+keywords = orchestration
+classifiers =
+    Development Status :: 3 - Alpha
+    Environment :: Console
+    Intended Audience :: Developers
+    Intended Audience :: System Administrators
+    Intended Audience :: Science/Research
+    Intended Audience :: Information Technology
+    License :: OSI Approved :: Apache Software License
+    Operating System :: POSIX
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Topic :: Software Development
+    Topic :: Software Development :: Libraries
+    Topic :: Software Development :: Libraries :: Python Modules
+    Topic :: Utilities
+
+[options]
+package_dir =
+    = src
+packages = find:
+zip_safe = True
+include_package_data = True
+setup_requires =
+    setuptools >= 60.9.3
+    setuptools_scm >= 6.4.2
+install_requires =
+    pyyaml <= 5.4.1
+    shtab >= 1.5.3
+
+[options.packages.find]
+where = src
+
+[options.entry_points]
+console_scripts =
+    opera-tosca-parser = opera_tosca_parser.cli:main
+
+[options.extras_require]
+test =
+    pytest >= 7.1.0

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+
+import setuptools
+
+
+# constructs the local component of the version without the commit hash
+def local_scheme(version):
+    return ""
+
+
+setuptools.setup(use_scm_version={"local_scheme": local_scheme})

--- a/src/opera_tosca_parser/cli.py
+++ b/src/opera_tosca_parser/cli.py
@@ -1,0 +1,87 @@
+import argparse
+import inspect
+import sys
+from typing import Optional
+
+import pkg_resources
+import shtab
+
+from opera_tosca_parser import commands
+
+
+class ArgParser(argparse.ArgumentParser):
+    """An argument parser that displays help on error"""
+
+    def error(self, message: str):
+        """
+        Overridden the original error method
+        :param message: Error message
+        """
+        sys.stderr.write(f"error: {message}\n")
+        self.print_help()
+        sys.exit(2)
+
+    def add_subparsers(self, **kwargs) -> argparse._SubParsersAction:
+        """
+        Overridden the original add_subparsers method (workaround for http://bugs.python.org/issue9253)
+        :return: Subparsers action as argparse._SubParsersAction object
+        """
+        subparsers = super(ArgParser, self).add_subparsers()  # pylint: disable=super-with-arguments
+        subparsers.required = True
+        subparsers.dest = "command"
+        return subparsers
+
+
+class PrintCurrentVersionAction(argparse.Action):
+    """Action for printing current package version"""
+
+    def __call__(self, parser: ArgParser, namespace: argparse.Namespace, values: list,
+                 option_string: Optional[str] = None):
+        """
+        Overridden the call action method
+        :param parser: Argument parser
+        :param namespace: Namespace as argparse.Namespace
+        :param values: List of values
+        :param option_string: Option string
+        """
+        try:
+            print(pkg_resources.get_distribution("opera-tosca-parser").version)
+            parser.exit(0)
+        except pkg_resources.DistributionNotFound as e:
+            print(f"Error when retrieving current opera-tosca-parser version: {e}")
+            parser.exit(1)
+
+
+def create_parser() -> ArgParser:
+    """
+    Create argument parser for CLI
+    :return: Parser as argparse.ArgumentParser object
+    """
+    parser = ArgParser(
+        description="xOpera TOSCA parser",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    subparsers = parser.add_subparsers()
+    cmds = inspect.getmembers(commands, inspect.ismodule)
+    for _, module in sorted(cmds, key=lambda x: x[0]):
+        module.add_parser(subparsers)
+    return parser
+
+
+def main() -> ArgParser:
+    """
+    The main CLI method to be called
+    :return: Parser as argparse.ArgumentParser object
+    """
+    parser = create_parser()
+    # use shtab magic and add global optional argument for generating shell completion script
+    shtab.add_argument_to(
+        parser, ["-s", "--shell-completion"],
+        help="Generate tab completion script for your shell"
+    )
+    # add global optional argument for printing current package version
+    parser.add_argument(
+        "--version", "-v", action=PrintCurrentVersionAction, nargs=0, help="Retrieve current opera-tosca-parser version"
+    )
+    args = parser.parse_args()
+    return args.func(args)

--- a/src/opera_tosca_parser/commands/__init__.py
+++ b/src/opera_tosca_parser/commands/__init__.py
@@ -1,0 +1,3 @@
+from opera_tosca_parser.commands import (  # noqa: F401
+    parse
+)

--- a/src/opera_tosca_parser/commands/parse.py
+++ b/src/opera_tosca_parser/commands/parse.py
@@ -1,0 +1,105 @@
+import argparse
+import typing
+from pathlib import Path, PurePath
+from tempfile import TemporaryDirectory
+from zipfile import is_zipfile
+
+import shtab
+import yaml
+
+from opera_tosca_parser.error import OperaToscaParserError, ParseError
+from opera_tosca_parser.parser import tosca
+from opera_tosca_parser.parser.tosca.csar import CloudServiceArchive, DirCloudServiceArchive
+
+
+def add_parser(subparsers: argparse._SubParsersAction):
+    """
+    Adds a new parser to subparsers
+    :param subparsers: Subparsers action
+    """
+    parser = subparsers.add_parser(
+        "parse",
+        help="Parse TOSCA YAML service template or TOSCA CSAR"
+    )
+    parser.add_argument(
+        "--inputs", "-i", type=argparse.FileType("r"),
+        help="YAML or JSON file with inputs",
+    ).complete = shtab.FILE
+    parser.add_argument(
+        "csar_or_service_template", type=str, nargs="?",
+        help="TOSCA YAML service template or uncompressed/compressed TOSCA CSAR"
+    ).complete = shtab.FILE
+    parser.set_defaults(func=_parser_callback)
+
+
+def _parser_callback(args: argparse.Namespace):
+    """
+    Parser callback function
+    :param args: Supplied arguments
+    """
+    try:
+        inputs = yaml.safe_load(args.inputs) if args.inputs else {}
+    except yaml.YAMLError as e:
+        print(f"Invalid inputs: {e}")
+        return 1
+
+    if args.csar_or_service_template is None:
+        csar_or_st_path = PurePath(".")
+    else:
+        csar_or_st_path = PurePath(args.csar_or_service_template)
+
+    try:
+        if is_zipfile(csar_or_st_path) or Path(csar_or_st_path).is_dir():
+            print("Parsing TOSCA CSAR...")
+            parse_csar(csar_or_st_path, inputs)
+        else:
+            print("Parsing TOSCA service template...")
+            parse_service_template(csar_or_st_path, inputs)
+        print("Done.")
+    except ParseError as e:
+        print(f"{e.loc}: {e}")
+        return 1
+    except OperaToscaParserError as e:
+        print(str(e))
+        return 1
+
+    return 0
+
+
+def parse_csar(csar_path: PurePath, inputs: typing.Optional[dict]):
+    """
+    Parse TOSCA CSAR
+    :param csar_path: Path to TOSCA CSAR
+    :param inputs: TOSCA inputs
+    """
+    if inputs is None:
+        inputs = {}
+
+    csar = CloudServiceArchive.create(csar_path)
+    csar.validate_csar()
+    entrypoint = csar.get_entrypoint()
+
+    if entrypoint is not None:
+        if isinstance(csar, DirCloudServiceArchive):
+            workdir = Path(csar_path)
+            ast = tosca.load(workdir, entrypoint)
+            ast.get_template(inputs)
+        else:
+            with TemporaryDirectory() as csar_validation_dir:
+                csar.unpackage_csar(csar_validation_dir)
+                workdir = Path(csar_validation_dir)
+                ast = tosca.load(workdir, entrypoint)
+                ast.get_template(inputs)
+
+
+def parse_service_template(service_template_path: PurePath, inputs: typing.Optional[dict]):
+    """
+    Parse TOSCA service template
+    :param service_template_path: Path to TOSCA service template
+    :param inputs: TOSCA inputs
+    """
+    if inputs is None:
+        inputs = {}
+    workdir = Path(service_template_path.parent)
+    ast = tosca.load(workdir, PurePath(service_template_path.name))
+    ast.get_template(inputs)

--- a/src/opera_tosca_parser/utils.py
+++ b/src/opera_tosca_parser/utils.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+from tarfile import is_tarfile
+from typing import Union
+from zipfile import is_zipfile
+
+
+def determine_archive_format(filepath: Union[str, Path]) -> str:
+    """
+    The main CLI method to be called
+    :param filepath: Path to archive file
+    :return: Name of the archive format (zip, tar)
+    """
+    if is_tarfile(filepath):
+        return "tar"
+    elif is_zipfile(filepath):
+        return "zip"
+    else:
+        raise Exception(
+            f"Unsupported archive format: '{filepath}'. The packaging format should be one of: zip, tar."
+        )


### PR DESCRIPTION
These changes will add a CLI for xOpera TOSCA parser, so that the users
will be able to parse their TOSCA template with `opera-tosca-parser parse` command.