### PR TITLE
Add GH Action workflows for CI/CD 

### DIFF
--- a/.github/workflows/ci_cd.yaml
+++ b/.github/workflows/ci_cd.yaml
@@ -1,0 +1,70 @@
+name: cicd
+
+on: push
+
+jobs:
+  tests:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.10.2
+
+      - name: Install local opera-tosca-parser package
+        run: pip install .
+
+      - name: Install unit test requiremements
+        run: pip install -r tests/unit/requirements.txt
+
+      - name: Run unit tests
+        run: pytest tests/unit
+
+      - name: Run integration tests
+        run: for d in tests/integration/*/; do (cd "$d" && ./runme.sh opera-tosca-parser); done
+
+  release:
+    runs-on: ubuntu-20.04
+    needs: tests
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.10.2
+
+      - name: Install pypa/build
+        run: python -m pip install build --user
+
+      - name: Build a binary wheel and a source tarball
+        run: python -m build --sdist --wheel --outdir dist/ .
+
+      - name: Publish package to TestPyPI (for main branch)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: ${{ secrets.TEST_PYPI_USERNAME }}
+          password: ${{ secrets.TEST_PYPI_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+          skip_existing: true
+
+      - name: Publish CLI package to PyPI (for tags)
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: ${{ secrets.PYPI_USERNAME }}
+          password: ${{ secrets.PYPI_TOKEN }}
+
+      - name: Draft a new Release (for tags)
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true

--- a/tests/integration/cli_commands/TOSCA-Metadata/TOSCA.meta
+++ b/tests/integration/cli_commands/TOSCA-Metadata/TOSCA.meta
@@ -1,0 +1,4 @@
+TOSCA-Meta-File-Version: 1.1
+CSAR-Version: 1.1
+Created-By: OASIS TOSCA TC
+Entry-Definitions: service.yaml

--- a/tests/integration/cli_commands/inputs.json
+++ b/tests/integration/cli_commands/inputs.json
@@ -1,0 +1,4 @@
+{
+    "test_attribute_input": 10,
+    "test_property_input": true
+}

--- a/tests/integration/cli_commands/inputs.yaml
+++ b/tests/integration/cli_commands/inputs.yaml
@@ -1,0 +1,3 @@
+---
+test_attribute_input: 10
+test_property_input: true

--- a/tests/integration/cli_commands/playbooks/create.yaml
+++ b/tests/integration/cli_commands/playbooks/create.yaml
@@ -1,0 +1,11 @@
+---
+- hosts: all
+  gather_facts: false
+  tasks:
+    - name: Say hello from node's attribute
+      debug:
+        msg: "{{ my_attribute_input }}"
+
+    - name: Say hello from node's property
+      debug:
+        msg: "{{ my_property_input }}"

--- a/tests/integration/cli_commands/playbooks/delete.yaml
+++ b/tests/integration/cli_commands/playbooks/delete.yaml
@@ -1,0 +1,7 @@
+---
+- hosts: all
+  gather_facts: false
+  tasks:
+    - name: Say bye bye
+      debug:
+        msg: "Bye Bye"

--- a/tests/integration/cli_commands/playbooks/start.yaml
+++ b/tests/integration/cli_commands/playbooks/start.yaml
@@ -1,0 +1,7 @@
+---
+- hosts: all
+  gather_facts: false
+  tasks:
+    - name: Say hello
+      debug:
+        msg: "Hello!"

--- a/tests/integration/cli_commands/playbooks/stop.yaml
+++ b/tests/integration/cli_commands/playbooks/stop.yaml
@@ -1,0 +1,7 @@
+---
+- hosts: all
+  gather_facts: false
+  tasks:
+    - name: Say bye bye
+      debug:
+        msg: "Bye Bye"

--- a/tests/integration/cli_commands/runme.sh
+++ b/tests/integration/cli_commands/runme.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+
+# get opera-tosca-parser executable
+opera_tosca_parser_executable="$1"
+
+# perform an integration test for most important opera-tosca-parser CLI commands and their options
+# prepare the TOSCA CSAR zip file
+zip -r test.csar service.yaml playbooks TOSCA-Metadata
+
+# parse TOSCA service template and TOSCA CSAR (with JSON/YAML inputs)
+$opera_tosca_parser_executable parse --inputs inputs.json service.yaml
+$opera_tosca_parser_executable parse --inputs inputs.yaml test.csar
+
+# remove the created zip
+rm -f test.csar

--- a/tests/integration/cli_commands/service.yaml
+++ b/tests/integration/cli_commands/service.yaml
@@ -1,0 +1,87 @@
+---
+tosca_definitions_version: tosca_simple_yaml_1_3
+
+node_types:
+  cli_commands_test.nodes.tokio:
+    derived_from: tosca.nodes.SoftwareComponent
+    attributes:
+      attribute:
+        type: integer
+        default: 42
+    properties:
+      property:
+        type: boolean
+        default: false
+    interfaces:
+      Standard:
+        inputs:
+          my_attribute_input: { value: { get_attribute: [ SELF, attribute ] }, type: string }
+          my_property_input: { value: { get_property: [ SELF, property ] }, type: string }
+        operations:
+          create: playbooks/create.yaml
+          delete: playbooks/delete.yaml
+
+  cli_commands_test.nodes.berlin:
+    derived_from: tosca.nodes.SoftwareComponent
+    interfaces:
+      Standard:
+        operations:
+          start: playbooks/start.yaml
+          stop: playbooks/stop.yaml
+
+  cli_commands_test.nodes.denver:
+    derived_from: tosca.nodes.SoftwareComponent
+
+  cli_commands_test.nodes.nairobi:
+    derived_from: tosca.nodes.SoftwareComponent
+
+  cli_commands_test.nodes.rio:
+    derived_from: tosca.nodes.SoftwareComponent
+
+topology_template:
+  inputs:
+    test_attribute_input:
+      type: integer
+      default: 42
+    test_property_input:
+      type: boolean
+      default: false
+
+  node_templates:
+    tokio:
+      type: cli_commands_test.nodes.tokio
+      attributes:
+        attribute: { get_input: test_attribute_input }
+      properties:
+        property: { get_input: test_property_input }
+      requirements:
+        - host: compute
+
+    berlin:
+      type: cli_commands_test.nodes.berlin
+      requirements:
+        - host: compute
+
+    denver:
+      type: cli_commands_test.nodes.denver
+      requirements:
+        - host: compute
+
+    nairobi:
+      type: cli_commands_test.nodes.nairobi
+      requirements:
+        - host: compute
+
+    compute:
+      type: tosca.nodes.Compute
+      attributes:
+        public_address: localhost
+        private_address: localhost
+
+  outputs:
+    output_attr:
+      description: Example of attribute output
+      value: { get_attribute: [ tokio, attribute ] }
+    output_prop:
+      description: Example of property output
+      value: { get_property: [ tokio, property ] }

--- a/tests/integration/misc_tosca_types/TOSCA-Metadata/TOSCA.meta
+++ b/tests/integration/misc_tosca_types/TOSCA-Metadata/TOSCA.meta
@@ -1,0 +1,4 @@
+TOSCA-Meta-File-Version: 1.1
+CSAR-Version: 1.1
+Created-By: OASIS TOSCA TC
+Entry-Definitions: service.yaml

--- a/tests/integration/misc_tosca_types/inputs.yaml
+++ b/tests/integration/misc_tosca_types/inputs.yaml
@@ -1,0 +1,6 @@
+---
+# This yaml file contains inputs for service.yaml.
+
+host_ip: localhost
+slovenian_greeting: "Hej prijatelj, pojdi z nami!"
+...

--- a/tests/integration/misc_tosca_types/modules/artifact_types/test/test.yaml
+++ b/tests/integration/misc_tosca_types/modules/artifact_types/test/test.yaml
@@ -1,0 +1,9 @@
+---
+tosca_definitions_version: tosca_simple_yaml_1_3
+
+artifact_types:
+  daily_test.artifacts.test:
+    derived_from: tosca.artifacts.File
+    mime_type: application/test
+    file_ext: [ test ]
+...

--- a/tests/integration/misc_tosca_types/modules/capability_types/test/test.yaml
+++ b/tests/integration/misc_tosca_types/modules/capability_types/test/test.yaml
@@ -1,0 +1,16 @@
+---
+tosca_definitions_version: tosca_simple_yaml_1_3
+
+capability_types:
+  daily_test.capabilities.test:
+    derived_from: tosca.capabilities.Root
+    attributes:
+      capability_attribute:
+        type: integer
+        status: supported
+    properties:
+      capability_property:
+        type: string
+        required: true
+        status: supported
+...

--- a/tests/integration/misc_tosca_types/modules/data_types/test/test.yaml
+++ b/tests/integration/misc_tosca_types/modules/data_types/test/test.yaml
@@ -1,0 +1,27 @@
+---
+tosca_definitions_version: tosca_simple_yaml_1_3
+
+data_types:
+  daily_test.datatypes.test:
+    derived_from: tosca.datatypes.Root
+    properties:
+      a:
+        type: string
+        required: false
+      b:
+        type: integer
+        required: false
+        default: 3
+      c:
+        type: float
+        required: false
+        default: 0.5
+      d:
+        type: list
+        required: false
+        default: ["1", "2", "3"]
+      e:
+        type: map
+        required: false
+        default: { one: one, two: two }
+...

--- a/tests/integration/misc_tosca_types/modules/group_types/test/test.yaml
+++ b/tests/integration/misc_tosca_types/modules/group_types/test/test.yaml
@@ -1,0 +1,9 @@
+---
+tosca_definitions_version: tosca_simple_yaml_1_3
+
+group_types:
+  daily_test.groups.test:
+    derived_from: tosca.groups.Root
+    description: My test group type for placing nodes of type Compute
+    members: [ tosca.nodes.Compute ]
+...

--- a/tests/integration/misc_tosca_types/modules/interface_types/test/test.yaml
+++ b/tests/integration/misc_tosca_types/modules/interface_types/test/test.yaml
@@ -1,0 +1,10 @@
+---
+tosca_definitions_version: tosca_simple_yaml_1_3
+
+interface_types:
+  daily_test.interfaces.test:
+    derived_from: tosca.interfaces.Root
+    operations:
+      test_operation:
+        description: Simple operation for testing.
+...

--- a/tests/integration/misc_tosca_types/modules/node_types/file/file.yaml
+++ b/tests/integration/misc_tosca_types/modules/node_types/file/file.yaml
@@ -1,0 +1,16 @@
+---
+tosca_definitions_version: tosca_simple_yaml_1_3
+
+node_types:
+  daily_test.nodes.file:
+    derived_from: tosca.nodes.SoftwareComponent
+    interfaces:
+      Standard:
+        inputs:
+          file_content:
+            value: { get_input: file_content }
+            type: string
+        operations:
+          create: playbooks/create.yaml
+          delete: playbooks/delete.yaml
+...

--- a/tests/integration/misc_tosca_types/modules/node_types/file/playbooks/create.yaml
+++ b/tests/integration/misc_tosca_types/modules/node_types/file/playbooks/create.yaml
@@ -1,0 +1,16 @@
+---
+- hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: Create the new folder structure
+      file:
+        path: /tmp/opera-test/hello
+        recurse: true
+        state: directory
+
+    - name: Create hello.txt and add content
+      copy:
+        dest: /tmp/opera-test/hello/hello.txt
+        content: "{{ file_content }}"
+...

--- a/tests/integration/misc_tosca_types/modules/node_types/file/playbooks/delete.yaml
+++ b/tests/integration/misc_tosca_types/modules/node_types/file/playbooks/delete.yaml
@@ -1,0 +1,10 @@
+---
+- hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: Remove the location
+      file:
+        path: /tmp/opera-test
+        state: absent
+...

--- a/tests/integration/misc_tosca_types/modules/node_types/hello/hello.yaml
+++ b/tests/integration/misc_tosca_types/modules/node_types/hello/hello.yaml
@@ -1,0 +1,34 @@
+---
+tosca_definitions_version: tosca_simple_yaml_1_3
+
+node_types:
+  daily_test.nodes.hello:
+    derived_from: tosca.nodes.SoftwareComponent
+    properties:
+      slovenian_greeting:
+        type: string
+        description: Slovenian Greeting
+        default: Zdravo!
+      croatian_greeting:
+        type: string
+        description: Croatian Greeting
+        default: Cao đaci!
+    attributes:
+      something_to_pass_on:
+        type: string
+        description: Test for passing data between nodes
+        default: tralala
+    interfaces:
+      Standard:
+        inputs:
+          slovenian_greeting: { value: { get_property: [SELF, slovenian_greeting] }, type: string }
+          croatian_greeting: { value: { get_property: [SELF, croatian_greeting] }, type: string }
+          something_to_pass_on: { value: { get_attribute: [SELF, something_to_pass_on] }, type: string }
+        operations:
+          create:
+            implementation:
+              primary: playbooks/create.yaml
+              dependencies:
+                - playbooks/files/test.txt
+
+...

--- a/tests/integration/misc_tosca_types/modules/node_types/hello/playbooks/create.yaml
+++ b/tests/integration/misc_tosca_types/modules/node_types/hello/playbooks/create.yaml
@@ -1,0 +1,21 @@
+---
+- hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: Say hello in Slovenian
+      debug:
+        msg: "{{ slovenian_greeting }}"
+
+    - name: Say hello like the do it in Croatia
+      debug:
+        msg: "{{ croatian_greeting }}"
+
+    - name: See what's in that linked file
+      shell: "cat test.txt"
+
+    - name: Set attributes for the setter node
+      set_stats:
+        data:
+          something_to_pass_on: "{{ something_to_pass_on }}"
+...

--- a/tests/integration/misc_tosca_types/modules/node_types/hello/playbooks/files/start.yaml
+++ b/tests/integration/misc_tosca_types/modules/node_types/hello/playbooks/files/start.yaml
@@ -1,0 +1,9 @@
+---
+- hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: Just say hello
+      debug:
+        msg: "Hello"
+...

--- a/tests/integration/misc_tosca_types/modules/node_types/hello/playbooks/files/test.txt
+++ b/tests/integration/misc_tosca_types/modules/node_types/hello/playbooks/files/test.txt
@@ -1,0 +1,1 @@
+lalalalalalla

--- a/tests/integration/misc_tosca_types/modules/node_types/interfaces/interfaces.yaml
+++ b/tests/integration/misc_tosca_types/modules/node_types/interfaces/interfaces.yaml
@@ -1,0 +1,16 @@
+---
+tosca_definitions_version: tosca_simple_yaml_1_3
+
+node_types:
+  daily_test.nodes.interfaces:
+    derived_from: tosca.nodes.SoftwareComponent
+    interfaces:
+      Standard:
+        operations:
+          create: /modules/node_types/interfaces/playbooks/create.yaml
+          configure: /modules/node_types/interfaces/playbooks/create.yaml
+          start: /modules/node_types/interfaces/playbooks/start.yaml
+          stop: /modules/node_types/interfaces/playbooks/stop.yaml
+          delete: /modules/node_types/interfaces/playbooks/stop.yaml
+...
+

--- a/tests/integration/misc_tosca_types/modules/node_types/interfaces/playbooks/configure.yaml
+++ b/tests/integration/misc_tosca_types/modules/node_types/interfaces/playbooks/configure.yaml
@@ -1,0 +1,9 @@
+---
+- hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: Just say hello
+      debug:
+        msg: "Hello"
+...

--- a/tests/integration/misc_tosca_types/modules/node_types/interfaces/playbooks/create.yaml
+++ b/tests/integration/misc_tosca_types/modules/node_types/interfaces/playbooks/create.yaml
@@ -1,0 +1,9 @@
+---
+- hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: Just say hello
+      debug:
+        msg: "Hello"
+...

--- a/tests/integration/misc_tosca_types/modules/node_types/interfaces/playbooks/delete.yaml
+++ b/tests/integration/misc_tosca_types/modules/node_types/interfaces/playbooks/delete.yaml
@@ -1,0 +1,9 @@
+---
+- hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: Just say hello
+      debug:
+        msg: "Hello"
+...

--- a/tests/integration/misc_tosca_types/modules/node_types/interfaces/playbooks/start.yaml
+++ b/tests/integration/misc_tosca_types/modules/node_types/interfaces/playbooks/start.yaml
@@ -1,0 +1,9 @@
+---
+- hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: Just say hello
+      debug:
+        msg: "Hello"
+...

--- a/tests/integration/misc_tosca_types/modules/node_types/interfaces/playbooks/stop.yaml
+++ b/tests/integration/misc_tosca_types/modules/node_types/interfaces/playbooks/stop.yaml
@@ -1,0 +1,9 @@
+---
+- hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: Just say hello
+      debug:
+        msg: "Hello"
+...

--- a/tests/integration/misc_tosca_types/modules/node_types/noimpl/noimpl.yaml
+++ b/tests/integration/misc_tosca_types/modules/node_types/noimpl/noimpl.yaml
@@ -1,0 +1,18 @@
+---
+tosca_definitions_version: tosca_simple_yaml_1_3
+
+node_types:
+  daily_test.nodes.noimpl:
+    derived_from: tosca.nodes.Root
+    properties:
+      test_integer:
+        type: integer
+        required: true
+      test_string:
+        type: string
+        required: false
+    requirements:
+      - host:
+          capability: tosca.capabilities.Compute
+          relationship: tosca.relationships.HostedOn
+...

--- a/tests/integration/misc_tosca_types/modules/node_types/setter/playbooks/create.yaml
+++ b/tests/integration/misc_tosca_types/modules/node_types/setter/playbooks/create.yaml
@@ -1,0 +1,10 @@
+---
+- hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: Set attribute
+      set_stats:
+        data:
+          my_attribute: my_custom_attribute_value
+...

--- a/tests/integration/misc_tosca_types/modules/node_types/setter/setter.yaml
+++ b/tests/integration/misc_tosca_types/modules/node_types/setter/setter.yaml
@@ -1,0 +1,27 @@
+---
+tosca_definitions_version: tosca_simple_yaml_1_3
+
+node_types:
+  daily_test.nodes.setter:
+    derived_from: tosca.nodes.Root
+    attributes:
+      my_attribute:
+        type: string
+        default: my_default_attribute_default
+    properties:
+      my_property:
+        type: integer
+    interfaces:
+      Standard:
+        inputs:
+          receive_something: { value:  { get_attribute: [SELF, receives_notification, something_to_pass_on] }, type: string }
+        operations:
+          create: playbooks/create.yaml
+    requirements:
+      - host:
+          capability: tosca.capabilities.Compute
+          relationship: tosca.relationships.HostedOn
+      - receives_notification:
+          capability: tosca.capabilities.Node
+          relationship: tosca.relationships.DependsOn
+...

--- a/tests/integration/misc_tosca_types/modules/node_types/test/playbooks/create.yaml
+++ b/tests/integration/misc_tosca_types/modules/node_types/test/playbooks/create.yaml
@@ -1,0 +1,17 @@
+---
+- hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: Say test
+      debug:
+        msg: "test"
+
+    - name: Print out input that got its value from capability property
+      debug:
+        msg: "Property: {{ capability_property_input }}"
+
+    - name: Print out input that got its value from capability attribute
+      debug:
+        msg: "Attribute: {{ capability_attribute_input }}"
+...

--- a/tests/integration/misc_tosca_types/modules/node_types/test/test.yaml
+++ b/tests/integration/misc_tosca_types/modules/node_types/test/test.yaml
@@ -1,0 +1,46 @@
+---
+tosca_definitions_version: tosca_simple_yaml_1_3
+
+imports:
+  - ../../artifact_types/test/test.yaml
+  - ../../capability_types/test/test.yaml
+  - ../../data_types/test/test.yaml
+  - ../../interface_types/test/test.yaml
+  - ../../policy_types/test/test.yaml
+  - ../../relationship_types/test/test.yaml
+  - ../../relationship_types/interfaces/interfaces.yaml
+
+node_types:
+  daily_test.nodes.test:
+    derived_from: tosca.nodes.Root
+    metadata:
+      targetNamespace: "daily_test.nodes.test"
+      abstract: "false"
+      final: "false"
+    properties:
+      test:
+        type: daily_test.datatypes.test
+        required: false
+    interfaces:
+      Standard:
+        operations:
+          create:
+            inputs:
+              capability_attribute_input: { value: { get_attribute: [ SELF, test_capability, capability_attribute ] }, type: string }
+              capability_property_input: { value: { get_property: [ SELF, test_capability, capability_property ] }, type: string }
+            implementation:
+              primary: playbooks/create.yaml
+      test:
+        type: daily_test.interfaces.test
+    artifacts:
+      test:
+        type: daily_test.artifacts.test
+        file: file.test
+    capabilities:
+      test_capability:
+        type: daily_test.capabilities.test
+    requirements:
+      - host:
+          capability: tosca.capabilities.Compute
+          relationship: daily_test.relationships.test
+...

--- a/tests/integration/misc_tosca_types/modules/policy_types/test/test.yaml
+++ b/tests/integration/misc_tosca_types/modules/policy_types/test/test.yaml
@@ -1,0 +1,15 @@
+tosca_definitions_version: tosca_simple_yaml_1_3
+
+policy_types:
+  daily_test_policies.test:
+    derived_from: tosca.policies.Root
+    metadata:
+      targetNamespace: "daily_test_policies.test"
+      abstract: "false"
+      final: "false"
+    properties:
+      test_id:
+        type: string
+        description: Test identifier
+        required: false
+        status: supported

--- a/tests/integration/misc_tosca_types/modules/relationship_types/interfaces/interfaces.yaml
+++ b/tests/integration/misc_tosca_types/modules/relationship_types/interfaces/interfaces.yaml
@@ -1,0 +1,14 @@
+---
+tosca_definitions_version: tosca_simple_yaml_1_3
+
+relationship_types:
+  daily_test.relationships.interfaces:
+    derived_from: tosca.relationships.DependsOn
+    interfaces:
+      Configure:
+        operations:
+          pre_configure_source: /modules/relationship_types/interfaces/playbooks/pre_configure_source.yaml
+          pre_configure_target: /modules/relationship_types/interfaces/playbooks/pre_configure_target.yaml
+          post_configure_source: /modules/relationship_types/interfaces/playbooks/post_configure_source.yaml
+          post_configure_target: /modules/relationship_types/interfaces/playbooks/post_configure_target.yaml
+...

--- a/tests/integration/misc_tosca_types/modules/relationship_types/interfaces/playbooks/post_configure_source.yaml
+++ b/tests/integration/misc_tosca_types/modules/relationship_types/interfaces/playbooks/post_configure_source.yaml
@@ -1,0 +1,9 @@
+---
+- hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: Just say hello
+      debug:
+        msg: "Hello"
+...

--- a/tests/integration/misc_tosca_types/modules/relationship_types/interfaces/playbooks/post_configure_target.yaml
+++ b/tests/integration/misc_tosca_types/modules/relationship_types/interfaces/playbooks/post_configure_target.yaml
@@ -1,0 +1,9 @@
+---
+- hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: Just say hello
+      debug:
+        msg: "Hello"
+...

--- a/tests/integration/misc_tosca_types/modules/relationship_types/interfaces/playbooks/pre_configure_source.yaml
+++ b/tests/integration/misc_tosca_types/modules/relationship_types/interfaces/playbooks/pre_configure_source.yaml
@@ -1,0 +1,9 @@
+---
+- hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: Just say hello
+      debug:
+        msg: "Hello"
+...

--- a/tests/integration/misc_tosca_types/modules/relationship_types/interfaces/playbooks/pre_configure_target.yaml
+++ b/tests/integration/misc_tosca_types/modules/relationship_types/interfaces/playbooks/pre_configure_target.yaml
@@ -1,0 +1,9 @@
+---
+- hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: Just say hello
+      debug:
+        msg: "Hello"
+...

--- a/tests/integration/misc_tosca_types/modules/relationship_types/test/playbooks/test.yaml
+++ b/tests/integration/misc_tosca_types/modules/relationship_types/test/playbooks/test.yaml
@@ -1,0 +1,18 @@
+---
+- hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: Say test
+      debug:
+        msg: "test"
+
+    - name: Print whatever lies in relationship_property
+      debug:
+        msg: "{{ relationship_property }}"
+
+    - name: Set relationship attribute
+      set_stats:
+        data:
+          relationship_attribute: "This is a relationship attribute."
+...

--- a/tests/integration/misc_tosca_types/modules/relationship_types/test/test.yaml
+++ b/tests/integration/misc_tosca_types/modules/relationship_types/test/test.yaml
@@ -1,0 +1,25 @@
+---
+tosca_definitions_version: tosca_simple_yaml_1_3
+
+relationship_types:
+  daily_test.relationships.test:
+    derived_from: tosca.relationships.HostedOn
+    attributes:
+      relationship_attribute:
+        type: string
+    properties:
+      relationship_property:
+        type: string
+        default: test123
+        required: true
+    interfaces:
+      Configure:
+        operations:
+          pre_configure_source:
+            inputs:
+              relationship_property:
+                value: { get_property: [ SELF, relationship_property ] }
+                type: string
+            implementation:
+              primary: playbooks/test.yaml
+...

--- a/tests/integration/misc_tosca_types/runme.sh
+++ b/tests/integration/misc_tosca_types/runme.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+
+# get opera-tosca-parser executable
+opera_tosca_parser_executable="$1"
+
+# perform an integration test with compressed CSAR
+# prepare the TOSCA CSAR zip file manually
+mkdir -p csar-test
+zip -r test.csar service.yaml modules TOSCA-Metadata
+mv test.csar csar-test
+cp inputs.yaml csar-test
+cd csar-test
+
+# parse the compressed TOSCA CSAR
+$opera_tosca_parser_executable parse -i inputs.yaml test.csar
+
+# remove the created folder
+cd ..
+rm -rf csar-test

--- a/tests/integration/misc_tosca_types/service.yaml
+++ b/tests/integration/misc_tosca_types/service.yaml
@@ -1,0 +1,145 @@
+---
+tosca_definitions_version: tosca_simple_yaml_1_3
+
+imports:
+  - modules/artifact_types/test/test.yaml
+  - modules/capability_types/test/test.yaml
+  - modules/data_types/test/test.yaml
+  - modules/group_types/test/test.yaml
+  - modules/interface_types/test/test.yaml
+  - modules/node_types/file/file.yaml
+  - modules/node_types/hello/hello.yaml
+  - modules/node_types/interfaces/interfaces.yaml
+  - modules/node_types/noimpl/noimpl.yaml
+  - modules/node_types/setter/setter.yaml
+  - modules/node_types/test/test.yaml
+  - modules/policy_types/test/test.yaml
+  - modules/relationship_types/test/test.yaml
+  - modules/relationship_types/interfaces/interfaces.yaml
+
+metadata:
+  targetNamespace: "daily_test.templates"
+  file_name: "service-template.yaml"
+
+description: This is a service template for daily testing with xOpera.
+namespace: "urn:daily_test.templates"
+
+repositories:
+  test_repo:
+    description: Opera repository on GitHub
+    url: https://github.com/xlab-si/xopera-opera
+
+dsl_definitions:
+  test: &test test123
+
+topology_template:
+  inputs:
+    host_ip:
+      type: string
+    file_content:
+      type: string
+      description: Content for created file
+      default: "Hello from Ansible and xOpera!\n"
+    slovenian_greeting:
+      type: string
+      description: Greeting from Slovenia
+
+  node_templates:
+    my-workstation1:
+      type: tosca.nodes.Compute
+      attributes:
+        private_address: { get_input: host_ip }
+        public_address: { get_input: host_ip }
+
+    my-workstation2:
+      type: tosca.nodes.Compute
+      attributes:
+        private_address: { get_input: host_ip }
+        public_address: { get_input: host_ip }
+
+    file:
+      type: daily_test.nodes.file
+      requirements:
+        - host: my-workstation1
+
+    hello:
+      type: daily_test.nodes.hello
+      properties:
+        slovenian_greeting: { get_input: slovenian_greeting }
+      requirements:
+        - host: my-workstation1
+
+    interfaces:
+      type: daily_test.nodes.interfaces
+      requirements:
+        - host: my-workstation1
+
+    noimpl:
+      type: daily_test.nodes.noimpl
+      properties:
+        test_integer: 42
+      requirements:
+        - host: my-workstation1
+
+    setter:
+      type: daily_test.nodes.setter
+      properties:
+        my_property: 123
+      requirements:
+        - host: my-workstation1
+        - receives_notification: hello
+
+    test:
+      type: daily_test.nodes.test
+      capabilities:
+        test_capability:
+          attributes:
+            capability_attribute: 42
+          properties:
+            capability_property: capability_property_value
+      requirements:
+        - host:
+            node: my-workstation2
+            relationship: test_rel
+      artifacts:
+        artifact:
+          type: daily_test.artifacts.test
+          file: modules/node_types/test/file.test
+
+  relationship_templates:
+    test_rel:
+      type: daily_test.relationships.test
+      attributes:
+        relationship_attribute: rel_attr_test123
+      properties:
+        relationship_property: rel_prop_test123
+
+    interfaces:
+      type: daily_test.relationships.interfaces
+
+  groups:
+    workstation_group:
+      type: daily_test.groups.test
+      members: [ my-workstation1, my-workstation2 ]
+
+  policies:
+    - test:
+        type: daily_test_policies.test
+        properties:
+          test_id: *test
+        targets: [ hello, setter, workstation_group ]
+
+  outputs:
+    node_output_prop:
+      description: Example of property output
+      value: { get_property: [ setter, my_property ] }
+    node_output_attr:
+      description: Example of attribute output
+      value: { get_attribute: [ setter, my_attribute ] }
+    relationship_output_prop:
+      description: Example of attribute output
+      value: { get_property: [ test_rel, relationship_property ] }
+    relationship_output_attr:
+      description: Example of attribute output
+      value: { get_attribute: [ test_rel, relationship_attribute ] }
+...


### PR DESCRIPTION
Within this PR we are introducing our CI/CD configuration for
xOpera TOSCA parser. There are two main GitHub Action workflows - the
first one is for testing and it runs unit and integration tests and the
second one is here for publishing new package versions to PyPI.

This PR needs to be addressed after #2. 