### PR TITLE
[TOSCA 2.0 - part 3]: Provide unit and integration tests and enable parsing 2.0 via CLI

### DIFF
--- a/.github/workflows/ci_cd.yaml
+++ b/.github/workflows/ci_cd.yaml
@@ -5,14 +5,18 @@ on: push
 jobs:
   tests:
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: [ '3.8', '3.9', '3.10' ]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
 
-      - name: Set up Python 3.10
+      - name: Setup python ${{ matrix.python-version }}
         uses: actions/setup-python@v3
         with:
-          python-version: 3.10.4
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
 
       - name: Install local opera-tosca-parser package
         run: pip install .

--- a/README.md
+++ b/README.md
@@ -15,7 +15,10 @@ TOSCA YAML parser for xOpera orchestrator.
 
 ## Introduction
 xOpera TOSCA parser aims to be a lightweight parser component compliant with [OASIS TOSCA]. 
-The current compliance is with the [OASIS TOSCA Simple Profile in YAML v1.3].
+The current compliance is with the [TOSCA Simple Profile in YAML v1.3].
+
+*We are also testing experimental support for [TOSCA Version 2.0], which will
+become the main version after TOSCA 2.0 is released.*
 
 ## Prerequisites
 `opera-tosca-parser` requires Python 3 and a virtual environment. 
@@ -68,7 +71,8 @@ Some work from this project has received funding from the European Union’s Hor
 programme under Grant Agreements No. 825040 ([RADON]), No. 825480 ([SODALITE]) and No. 101000162 ([PIACERE]).
 
 [opera-tosca-parser]: https://pypi.org/project/opera-tosca-parser/
-[OASIS TOSCA Simple Profile in YAML v1.3]: https://docs.oasis-open.org/tosca/TOSCA-Simple-Profile-YAML/v1.3/TOSCA-Simple-Profile-YAML-v1.3.html
+[TOSCA Simple Profile in YAML v1.3]: https://docs.oasis-open.org/tosca/TOSCA-Simple-Profile-YAML/v1.3/TOSCA-Simple-Profile-YAML-v1.3.html
+[TOSCA Version 2.0]: https://docs.oasis-open.org/tosca/TOSCA/v2.0/TOSCA-v2.0.html
 [xOpera documentation]: https://xlab-si.github.io/xopera-docs/
 [xopera@xlab.si]: mailto:xopera@xlab.si
 [OASIS TOSCA]: https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=tosca

--- a/src/opera_tosca_parser/commands/parse.py
+++ b/src/opera_tosca_parser/commands/parse.py
@@ -11,6 +11,7 @@ from opera_tosca_parser.error import OperaToscaParserError, ParseError
 from opera_tosca_parser.parser import tosca
 from opera_tosca_parser.parser.tosca.v_1_3.csar import CloudServiceArchive, DirCloudServiceArchive
 from opera_tosca_parser.parser.tosca.v_1_3.template.topology import Topology
+from opera_tosca_parser.parser.tosca.v_2_0.csar import CloudServiceArchive as CloudServiceArchive_2_0
 
 
 def add_parser(subparsers: argparse._SubParsersAction):
@@ -87,9 +88,14 @@ def parse_csar(csar_path: PurePath, inputs: Optional[dict]) -> Tuple[Topology, P
     if inputs is None:
         inputs = {}
 
-    csar = CloudServiceArchive.create(csar_path)
-    csar.validate_csar()
-    entrypoint = csar.get_entrypoint()
+    try:
+        csar = CloudServiceArchive.create(csar_path)
+        csar.validate_csar()
+        entrypoint = csar.get_entrypoint()
+    except ParseError:
+        csar = CloudServiceArchive_2_0.create(csar_path)
+        csar.validate_csar()
+        entrypoint = csar.get_entrypoint()
 
     if entrypoint is not None:
         if isinstance(csar, DirCloudServiceArchive):

--- a/src/opera_tosca_parser/parser/tosca/__init__.py
+++ b/src/opera_tosca_parser/parser/tosca/__init__.py
@@ -1,17 +1,48 @@
 import importlib
 from pathlib import PurePath, Path
 
-from opera_tosca_parser.parser.tosca.v_1_3 import stdlib
 from opera_tosca_parser.error import ParseError
 from opera_tosca_parser.parser import yaml
-from opera_tosca_parser.parser.tosca.v_1_3 import Parser
-from opera_tosca_parser.parser.tosca.v_1_3 import ServiceTemplate
+from opera_tosca_parser.parser.tosca.v_1_3 import stdlib
+from opera_tosca_parser.parser.tosca.v_2_0 import Parser
+from opera_tosca_parser.parser.tosca.v_2_0 import ServiceTemplate
+from opera_tosca_parser.parser.tosca.v_2_0 import profiles
 from opera_tosca_parser.parser.utils.location import Location
 from opera_tosca_parser.parser.yaml.node import Node
 
-SUPPORTED_VERSIONS = dict(
-    tosca_simple_yaml_1_3="v_1_3"
+# TODO: Should we remove support for TOSCA v1.3 when TOSCA 2.0 officially becomes a standard?
+# This is a dict with name of TOSCA version as key and relative path to parser definitions as value
+SUPPORTED_TOSCA_VERSIONS = dict(
+    tosca_simple_yaml_1_3="v_1_3",
+    tosca_2_0="v_2_0"
 )
+
+
+def _get_tosca_version(input_yaml: Node) -> str:
+    """
+    Get TOSCA version for TOSCA service template
+    :param input_yaml: YAML Node input for TOSCA service template
+    :return: TOSCA version string
+    """
+    for k, v in input_yaml.value.items():
+        if k.value == "tosca_definitions_version":
+            try:
+                return SUPPORTED_TOSCA_VERSIONS[v.value]
+            except (TypeError, KeyError) as e:
+                raise ParseError(
+                    f"Unsupported TOSCA version. Available: {', '.join(SUPPORTED_TOSCA_VERSIONS.keys())}.", v.loc
+                ) from e
+
+    raise ParseError("Missing TOSCA version.", input_yaml.loc)
+
+
+def _get_parser(tosca_version: str) -> Parser:
+    """
+    Get parser for TOSCA service template
+    :param tosca_version: TOSCA version
+    :return: Parser object
+    """
+    return importlib.import_module(f".{tosca_version}", __name__).Parser  # type: ignore
 
 
 def load(base_path: Path, service_template: PurePath) -> ServiceTemplate:
@@ -29,36 +60,14 @@ def load(base_path: Path, service_template: PurePath) -> ServiceTemplate:
     tosca_version = _get_tosca_version(input_yaml)
     parser = _get_parser(tosca_version)
 
-    stdlib_yaml = stdlib.load(tosca_version)
-    service = parser.parse_service_template(stdlib_yaml, base_path, PurePath("STDLIB"), set())[0]
-    service.merge(parser.parse_service_template(input_yaml, base_path, service_template, set())[0])
+    if tosca_version == "v_2_0":
+        service = parser.parse_service_template(input_yaml, base_path, service_template, set())[0]
+    else:
+        stdlib_yaml = stdlib.load(tosca_version)
+        service = parser.parse_service_template(stdlib_yaml, base_path, PurePath("STDLIB"), set())[0]
+        service.merge(parser.parse_service_template(input_yaml, base_path, service_template, set())[0])
+
     service.visit("resolve_path", base_path)
     service.visit("resolve_reference", service)
 
     return service
-
-
-def _get_parser(tosca_version: str) -> Parser:
-    """
-    Get parser for TOSCA service template
-    :param tosca_version: TOSCA version
-    :return: Parser object
-    """
-    return importlib.import_module(f".{tosca_version}", __name__).Parser  # type: ignore
-
-
-def _get_tosca_version(input_yaml: Node) -> str:
-    """
-    Get TOSCA version for TOSCA service template
-    :param input_yaml: YAML Node input for TOSCA service template
-    :return: TOSCA version string
-    """
-    for k, v in input_yaml.value.items():
-        if k.value == "tosca_definitions_version":
-            try:
-                return SUPPORTED_VERSIONS[v.value]
-            except (TypeError, KeyError) as e:
-                raise ParseError(f"Invalid TOSCA version. Available: {', '.join(SUPPORTED_VERSIONS.keys())}.",
-                                 v.loc) from e
-
-    raise ParseError("Missing TOSCA version", input_yaml.loc)

--- a/tests/integration/cli_commands/TOSCA-Metadata/TOSCA.meta
+++ b/tests/integration/cli_commands/TOSCA-Metadata/TOSCA.meta
@@ -1,4 +1,4 @@
 TOSCA-Meta-File-Version: 1.1
 CSAR-Version: 1.1
-Created-By: OASIS TOSCA TC
+Created-By: XLAB
 Entry-Definitions: service.yaml

--- a/tests/integration/cli_commands/inputs.json
+++ b/tests/integration/cli_commands/inputs.json
@@ -1,4 +1,4 @@
 {
-    "test_attribute_input": 10,
-    "test_property_input": true
+  "test_attribute_input": 10,
+  "test_property_input": true
 }

--- a/tests/integration/cli_commands/runme.sh
+++ b/tests/integration/cli_commands/runme.sh
@@ -6,7 +6,7 @@ opera_tosca_parser_executable="$1"
 
 # perform an integration test for most important opera-tosca-parser CLI commands and their options
 # prepare the TOSCA CSAR zip file
-zip -r test.csar service.yaml playbooks TOSCA-Metadata
+zip -rqq test.csar service.yaml playbooks TOSCA-Metadata
 
 # parse TOSCA service template and TOSCA CSAR (with JSON/YAML inputs)
 $opera_tosca_parser_executable parse --inputs inputs.json service.yaml

--- a/tests/integration/misc_tosca_types/TOSCA-Metadata/TOSCA.meta
+++ b/tests/integration/misc_tosca_types/TOSCA-Metadata/TOSCA.meta
@@ -1,4 +1,4 @@
 TOSCA-Meta-File-Version: 1.1
 CSAR-Version: 1.1
-Created-By: OASIS TOSCA TC
+Created-By: XLAB
 Entry-Definitions: service.yaml

--- a/tests/integration/misc_tosca_types/runme.sh
+++ b/tests/integration/misc_tosca_types/runme.sh
@@ -7,7 +7,7 @@ opera_tosca_parser_executable="$1"
 # perform an integration test with compressed CSAR
 # prepare the TOSCA CSAR zip file manually
 mkdir -p csar-test
-zip -r test.csar service.yaml modules TOSCA-Metadata
+zip -rqq test.csar service.yaml modules TOSCA-Metadata
 mv test.csar csar-test
 cp inputs.yaml csar-test
 cd csar-test

--- a/tests/integration/small_tosca_2_0/TOSCA-Metadata/TOSCA.meta
+++ b/tests/integration/small_tosca_2_0/TOSCA-Metadata/TOSCA.meta
@@ -1,0 +1,3 @@
+CSAR-Version: 2.0
+Created-By: XLAB
+Entry-Definitions: service.yaml

--- a/tests/integration/small_tosca_2_0/files/file.txt
+++ b/tests/integration/small_tosca_2_0/files/file.txt
@@ -1,0 +1,1 @@
+This is an example file content.

--- a/tests/integration/small_tosca_2_0/inputs.yaml
+++ b/tests/integration/small_tosca_2_0/inputs.yaml
@@ -1,0 +1,6 @@
+---
+# This yaml file contains inputs for service.yaml.
+
+host_ip: "localhost"
+relationship_input: "Hey, I am in a relationship!"
+...

--- a/tests/integration/small_tosca_2_0/playbooks/create.yaml
+++ b/tests/integration/small_tosca_2_0/playbooks/create.yaml
@@ -1,0 +1,12 @@
+- hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: Say create
+      debug:
+        msg: "create"
+
+    - name: Set node attribute
+      set_stats:
+        data:
+          node_attribute: "Node attribute"

--- a/tests/integration/small_tosca_2_0/playbooks/post_configure_source.yaml
+++ b/tests/integration/small_tosca_2_0/playbooks/post_configure_source.yaml
@@ -1,0 +1,43 @@
+- hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: Say post_configure_source
+      debug:
+        msg: "post_configure_source"
+
+    - name: Print out the value of relationship_attribute
+      debug:
+        msg: "{{ relationship_attribute }}"
+
+    - name: Print out the value of relationship_property
+      debug:
+        msg: "{{ relationship_property }}"
+
+    - name: Print out the value of relationship_input
+      debug:
+        msg: "{{ relationship_input }}"
+
+    - name: Set attribute
+      set_stats:
+        data:
+          post_configure_source_attribute: "{{ relationship_attribute }}"
+
+    - name: Set attribute
+      set_stats:
+        data:
+          post_configure_source_property_attribute: "{{ relationship_property }}"
+
+    - name: Set attribute
+      set_stats:
+        data:
+          post_configure_source_input_attribute: "{{ relationship_input }}"
+
+    - name: See what lies in that dependecy text file
+      command: "cat file.txt"
+      register: text_file_contents
+
+    - name: Set text file attribute
+      set_stats:
+        data:
+          post_configure_source_txt_file_attribute: "{{ text_file_contents.stdout }}"

--- a/tests/integration/small_tosca_2_0/playbooks/post_configure_target.yaml
+++ b/tests/integration/small_tosca_2_0/playbooks/post_configure_target.yaml
@@ -1,0 +1,12 @@
+- hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: Say post_configure_target
+      debug:
+        msg: "post_configure_target"
+
+    - name: Set attribute
+      set_stats:
+        data:
+          post_configure_target_attribute: "This is post configure target attribute"

--- a/tests/integration/small_tosca_2_0/playbooks/pre_configure_source.yaml
+++ b/tests/integration/small_tosca_2_0/playbooks/pre_configure_source.yaml
@@ -1,0 +1,12 @@
+- hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: Say pre_configure_source
+      debug:
+        msg: "pre_configure_source"
+
+    - name: Set attribute
+      set_stats:
+        data:
+          pre_configure_source_attribute: "This is pre configure source attribute"

--- a/tests/integration/small_tosca_2_0/playbooks/pre_configure_target.yaml
+++ b/tests/integration/small_tosca_2_0/playbooks/pre_configure_target.yaml
@@ -1,0 +1,12 @@
+- hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: Say pre_configure_target
+      debug:
+        msg: "pre_configure_target"
+
+    - name: Set attribute
+      set_stats:
+        data:
+          pre_configure_target_attribute: "This is pre configure target attribute"

--- a/tests/integration/small_tosca_2_0/runme.sh
+++ b/tests/integration/small_tosca_2_0/runme.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+
+# get opera-tosca-parser executable
+opera_tosca_parser_executable="$1"
+
+# perform an integration test with compressed CSAR
+# prepare the TOSCA CSAR zip file manually
+mkdir -p csar-test
+zip -rqq test.csar service.yaml playbooks files TOSCA-Metadata
+mv test.csar csar-test
+cp inputs.yaml csar-test
+cd csar-test
+
+# parse the compressed TOSCA CSAR
+$opera_tosca_parser_executable parse -i inputs.yaml test.csar
+
+# remove the created folder
+cd ..
+rm -rf csar-test

--- a/tests/integration/small_tosca_2_0/service.yaml
+++ b/tests/integration/small_tosca_2_0/service.yaml
@@ -1,0 +1,157 @@
+tosca_definitions_version: tosca_2_0
+
+metadata:
+  template_name: "misc_tosca_2_0"
+  template_author: "XLAB"
+  template_version: "2.0"
+
+imports:
+  - profile: org.oasis-open.tosca.simple:2.0
+
+node_types:
+  test:
+    derived_from: Compute
+    attributes:
+      node_attribute:
+        type: string
+    interfaces:
+      Standard:
+        type: Lifecycle.Standard
+        operations:
+          create: playbooks/create.yaml
+    requirements:
+      - host:
+          capability: Compute
+          relationship: test
+
+relationship_types:
+  test:
+    derived_from: HostedOn
+    attributes:
+      relationship_attribute:
+        type: string
+        default: Default relationship attribute
+      pre_configure_source_attribute:
+        description: Attribute set by pre_configure_source interface operation
+        type: string
+      pre_configure_target_attribute:
+        description: Attribute set by pre_configure_target interface operation
+        type: string
+      post_configure_source_attribute:
+        description: >
+          Attribute set by post_configure_source interface operation from the
+          relationship_attribute attribute that enters as an operation input
+        type: string
+      post_configure_source_property_attribute:
+        description: >
+          Attribute set by post_configure_source interface operation from the
+          relationship_property property that enters as an operation input
+        type: string
+      post_configure_source_input_attribute:
+        description: >
+          Attribute set by post_configure_source interface operation from the
+          relationship_input input that enters as an operation input
+        type: string
+      post_configure_source_txt_file_attribute:
+        description: >
+          Attribute set by post_configure_source interface operation that
+          includes the contents of the dependent txt file
+        type: string
+      post_configure_target_attribute:
+        description: Attribute set by post_configure_target interface operation
+        type: string
+    properties:
+      relationship_property:
+        type: string
+        default: Default relationship property
+    interfaces:
+      Configure:
+        operations:
+          pre_configure_source:
+            implementation: playbooks/pre_configure_source.yaml
+          pre_configure_target:
+            implementation: playbooks/pre_configure_target.yaml
+          post_configure_source:
+            inputs:
+              relationship_attribute:
+                type: string
+                value: { get_attribute: [ SELF, relationship_attribute ] }
+              relationship_property:
+                type: string
+                value: { get_property: [ SELF, relationship_property ] }
+              relationship_input:
+                type: string
+                value: { get_input: relationship_input }
+            implementation:
+              primary: playbooks/post_configure_source.yaml
+              dependencies:
+                - files/file.txt
+          post_configure_target:
+            implementation: playbooks/post_configure_target.yaml
+
+topology_template:
+  inputs:
+    host_ip:
+      type: string
+      default: localhost
+    relationship_input:
+      type: string
+      default: Relationship input
+
+  node_templates:
+    my_workstation:
+      type: Compute
+      attributes:
+        private_address: { get_input: host_ip }
+        public_address: { get_input: host_ip }
+
+    test_node:
+      type: test
+      requirements:
+        - host:
+            node: my_workstation
+            relationship: test_relationship
+
+  relationship_templates:
+    test_relationship:
+      type: test
+      attributes:
+        relationship_attribute: Relationship attribute
+      properties:
+        relationship_property: Relationship property
+
+  outputs:
+    output_node_attribute:
+      description: Node attribute output
+      value: { get_attribute: [ test_node, node_attribute ] }
+    output_relationship_attribute:
+      description: Relationship attribute output
+      value: { get_attribute: [ test_relationship, relationship_attribute ] }
+    output_relationship_property:
+      description: Relationship property output
+      value: { get_property: [ test_relationship, relationship_property ] }
+    output_relationship_input:
+      description: Relationship input output
+      value: { get_input: relationship_input }
+    output_pre_configure_source_attribute:
+      description: Relationship attribute output
+      value: { get_attribute: [ test_relationship, pre_configure_source_attribute ] }
+    output_pre_configure_target_attribute:
+      description: Relationship attribute output
+      value: { get_attribute: [ test_relationship, pre_configure_target_attribute ] }
+    output_post_configure_source_attribute:
+      description: Relationship attribute output
+      value: { get_attribute: [ test_relationship, post_configure_source_attribute ] }
+    output_post_configure_source_property_attribute:
+      description: Relationship attribute output
+      value: { get_attribute: [ test_relationship, post_configure_source_property_attribute ] }
+    output_post_configure_source_input_attribute:
+      description: Relationship attribute output
+      value: { get_attribute: [ test_relationship, post_configure_source_input_attribute ] }
+    output_post_configure_source_txt_file_attribute:
+      description: Relationship attribute output
+      value: { get_attribute: [ test_relationship, post_configure_source_txt_file_attribute ] }
+    output_post_configure_target_attribute:
+      description: Relationship attribute output
+      value: { get_attribute: [ test_relationship, post_configure_target_attribute ] }
+...

--- a/tests/unit/opera_tosca_parser/parser/test_tosca_2_0.py
+++ b/tests/unit/opera_tosca_parser/parser/test_tosca_2_0.py
@@ -1,0 +1,356 @@
+import pathlib
+
+import pytest
+
+from opera_tosca_parser.error import ParseError
+from opera_tosca_parser.parser import tosca
+
+
+class TestLoad:
+    def test_load_minimal_document(self, tmp_path):
+        name = pathlib.PurePath("root.yaml")
+        (tmp_path / name).write_text("tosca_definitions_version: tosca_2_0")
+
+        doc = tosca.load(tmp_path, name)
+        assert doc.tosca_definitions_version.data == "tosca_2_0"
+
+    def test_empty_document_is_invalid(self, tmp_path):
+        name = pathlib.PurePath("empty.yaml")
+        (tmp_path / name).write_text("{}")
+        with pytest.raises(ParseError):
+            tosca.load(tmp_path, name)
+
+    @pytest.mark.parametrize("typ", [
+        ("data_types", "xml"),
+        ("artifact_types", "Root"),
+        ("capability_types", "Node"),
+        ("relationship_types", "HostedOn"),
+        ("interface_types", "Lifecycle.Standard"),
+        ("node_types", "Root"),
+        ("group_types", "Root"),
+        ("policy_types", "Scaling")
+    ])
+    def test_stdlib_is_present(self, tmp_path, typ):
+        name = pathlib.PurePath("stdlib.yaml")
+        (tmp_path / name).write_text(
+            # language=yaml
+            f"""
+            tosca_definitions_version: tosca_2_0
+            imports:
+              - profile: org.oasis-open.tosca.simple:2.0
+            """
+        )
+
+        doc = tosca.load(tmp_path, name)
+        assert doc.dig(*typ) is not None
+
+    @pytest.mark.parametrize("typ", [
+        ("data_types", "xml"),
+        ("artifact_types", "Root"),
+        ("capability_types", "Node"),
+        ("relationship_types", "HostedOn"),
+        ("interface_types", "Lifecycle.Standard"),
+        ("node_types", "Root"),
+        ("group_types", "Root"),
+        ("policy_types", "Scaling")
+    ])
+    def test_custom_type_is_present(self, tmp_path, yaml_text, typ):
+        name = pathlib.PurePath("custom.yaml")
+        (tmp_path / name).write_text(yaml_text(
+            # language=yaml
+            f"""
+            tosca_definitions_version: tosca_2_0
+            imports:
+              - profile: org.oasis-open.tosca.simple:2.0
+            {typ[0]}:
+              my.custom.Type:
+                derived_from: {typ[1]}
+            """
+        ))
+
+        doc = tosca.load(tmp_path, name)
+        assert doc.dig(typ[0], "my.custom.Type") is not None
+
+    def test_loads_template_part(self, tmp_path, yaml_text):
+        name = pathlib.PurePath("template.yaml")
+        (tmp_path / name).write_text(yaml_text(
+            # language=yaml
+            """
+            tosca_definitions_version: tosca_2_0
+            imports:
+              - profile: org.oasis-open.tosca.simple:2.0
+            topology_template:
+              node_templates:
+                my_node:
+                  type: SoftwareComponent
+            """
+        ))
+
+        doc = tosca.load(tmp_path, name)
+        assert doc.topology_template.node_templates["my_node"] is not None
+
+    def test_load_from_csar_subfolder(self, tmp_path, yaml_text):
+        name = pathlib.PurePath("sub/folder/file.yaml")
+        (tmp_path / name).parent.mkdir(parents=True)
+        (tmp_path / name).write_text(yaml_text(
+            # language=yaml
+            """
+            tosca_definitions_version: tosca_2_0
+            imports:
+              - imp.yaml
+            """
+        ))
+        (tmp_path / "sub/folder/imp.yaml").write_text(yaml_text(
+            # language=yaml
+            """
+            tosca_definitions_version: tosca_2_0
+            imports:
+              - profile: org.oasis-open.tosca.simple:2.0
+            data_types:
+              my_type:
+                derived_from: xml
+            """
+        ))
+
+        doc = tosca.load(tmp_path, name)
+        assert doc.data_types["my_type"]
+
+    def test_duplicate_import(self, tmp_path, yaml_text):
+        name = pathlib.PurePath("template.yaml")
+        (tmp_path / name).write_text(yaml_text(
+            # language=yaml
+            """
+            tosca_definitions_version: tosca_2_0
+            imports: [ template.yaml ]
+            """
+        ))
+        tosca.load(tmp_path, name)
+
+    def test_imports_from_multiple_levels(self, tmp_path, yaml_text):
+        name = pathlib.PurePath("template.yaml")
+        (tmp_path / name).write_text(yaml_text(
+            # language=yaml
+            """
+            tosca_definitions_version: tosca_2_0
+            imports:
+              - subfolder/a.yaml
+              - subfolder/b.yaml
+            """
+        ))
+        (tmp_path / "subfolder").mkdir()
+        (tmp_path / "subfolder/a.yaml").write_text(yaml_text(
+            # language=yaml
+            """
+            tosca_definitions_version: tosca_2_0
+            imports:
+              - b.yaml
+            """
+        ))
+        (tmp_path / "subfolder/b.yaml").write_text(yaml_text(
+            # language=yaml
+            """
+            tosca_definitions_version: tosca_2_0
+            imports:
+              - profile: org.oasis-open.tosca.simple:2.0
+            data_types:
+              my_type:
+                derived_from: xml
+            """
+        ))
+
+        tosca.load(tmp_path, name)
+
+    def test_merge_topology_template(self, tmp_path, yaml_text):
+        name = pathlib.PurePath("template.yaml")
+        (tmp_path / name).write_text(yaml_text(
+            # language=yaml
+            """
+            tosca_definitions_version: tosca_2_0
+            imports:
+              - profile: org.oasis-open.tosca.simple:2.0
+              - merge.yaml
+            topology_template:
+              inputs:
+                some-input:
+                  type: string
+              node_templates:
+                my_node:
+                  type: SoftwareComponent
+            """
+        ))
+        (tmp_path / "merge.yaml").write_text(yaml_text(
+            # language=yaml
+            """
+            tosca_definitions_version: tosca_2_0
+            topology_template:
+              inputs:
+                other-input:
+                  type: string
+              node_templates:
+                other_node:
+                  type: SoftwareComponent
+            """
+        ))
+        tosca.load(tmp_path, name)
+
+    def test_merge_duplicate_node_templates_invalid(self, tmp_path, yaml_text):
+        name = pathlib.PurePath("template.yaml")
+        (tmp_path / name).write_text(yaml_text(
+            # language=yaml
+            """
+            tosca_definitions_version: tosca_2_0
+            imports:
+              - merge1.yaml
+              - merge2.yaml
+            topology_template:
+              node_templates:
+                my_node:
+                  type: SoftwareComponent
+            """
+        ))
+        (tmp_path / "merge1.yaml").write_text(yaml_text(
+            # language=yaml
+            """
+            tosca_definitions_version: tosca_2_0
+            topology_template:
+              node_templates:
+                other_node:
+                  type: SoftwareComponent
+            """
+        ))
+        (tmp_path / "merge2.yaml").write_text(yaml_text(
+            # language=yaml
+            """
+            tosca_definitions_version: tosca_2_0
+            topology_template:
+              node_templates:
+                other_node:
+                  type: SoftwareComponent
+            """
+        ))
+        with pytest.raises(ParseError):
+            tosca.load(tmp_path, name)
+
+
+class TestExecute:
+    def test_undefined_required_properties1(self, tmp_path, yaml_text):
+        name = pathlib.PurePath("template.yaml")
+        (tmp_path / name).write_text(yaml_text(
+            # language=yaml
+            """
+            tosca_definitions_version: tosca_2_0
+            imports:
+              - profile: org.oasis-open.tosca.simple:2.0
+            node_types:
+              my_node_type:
+                derived_from: Root
+                attributes:
+                  test_attribute:
+                    type: boolean
+                properties:
+                  test_property1:
+                    type: integer
+                    required: false
+                  test_property2:
+                    type: float
+                    default: 42.0
+                    required: true
+                  test_property3:
+                    type: string
+                    required: true
+            topology_template:
+              node_templates:
+                my_node_template:
+                  type: my_node_type
+            """
+        ))
+        ast = tosca.load(tmp_path, name)
+        with pytest.raises(ParseError, match="Missing a required property: test_property3"):
+            ast.get_template({})
+
+    def test_undefined_required_properties2(self, tmp_path, yaml_text):
+        name = pathlib.PurePath("template.yaml")
+        (tmp_path / name).write_text(yaml_text(
+            # language=yaml
+            """
+            tosca_definitions_version: tosca_2_0
+            imports:
+              - profile: org.oasis-open.tosca.simple:2.0
+            node_types:
+              my_node_type:
+                derived_from: Root
+                properties:
+                  test_prop1:
+                    type: integer
+                    required: false
+                  test_prop2:
+                    type: float
+                    default: 42.0
+                  test_prop3:
+                    type: string
+            topology_template:
+              node_templates:
+                my_node_template:
+                  type: my_node_type
+            """
+        ))
+        ast = tosca.load(tmp_path, name)
+        with pytest.raises(ParseError, match="Missing a required property: test_prop3"):
+            ast.get_template({})
+
+    def test_undefined_required_properties3(self, tmp_path, yaml_text):
+        name = pathlib.PurePath("template.yaml")
+        (tmp_path / name).write_text(yaml_text(
+            # language=yaml
+            """
+            tosca_definitions_version: tosca_2_0
+            imports:
+              - profile: org.oasis-open.tosca.simple:2.0
+            node_types:
+              my_node_type:
+                derived_from: Root
+                properties:
+                  property1:
+                    type: integer
+                  property2:
+                    type: float
+                  property3:
+                    type: string
+            topology_template:
+              node_templates:
+                my_node_template:
+                  type: my_node_type
+                  properties:
+                    property1: 42
+                    property2: 42.0
+            """
+        ))
+        ast = tosca.load(tmp_path, name)
+        with pytest.raises(ParseError, match="Missing a required property: property3"):
+            ast.get_template({})
+
+    def test_undeclared_requirements(self, tmp_path, yaml_text):
+        name = pathlib.PurePath("template.yaml")
+        (tmp_path / name).write_text(yaml_text(
+            # language=yaml
+            """
+            tosca_definitions_version: tosca_2_0
+            imports:
+              - profile: org.oasis-open.tosca.simple:2.0
+            topology_template:
+              node_templates:
+                node_1:
+                  type: Root
+                node_2:
+                  type: Root
+                  requirements:
+                    - dependency: node_1
+                node_3:
+                  type: Root
+                  requirements:
+                    - dependency_not_defined1: node_2
+        """
+        ))
+        ast = tosca.load(tmp_path, name)
+        with pytest.raises(ParseError, match="Undeclared requirements: dependency_not_defined1"):
+            ast.get_template({})

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_1_3/definitions/test_interface_definition_for_template.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_1_3/definitions/test_interface_definition_for_template.py
@@ -1,4 +1,5 @@
-from opera_tosca_parser.parser.tosca.v_1_3.definitions.interface_definition_for_template import InterfaceDefinitionForTemplate
+from opera_tosca_parser.parser.tosca.v_1_3.definitions.interface_definition_for_template import \
+    InterfaceDefinitionForTemplate
 
 
 class TestParse:

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_1_3/definitions/test_notification_implementation_definition.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_1_3/definitions/test_notification_implementation_definition.py
@@ -1,7 +1,8 @@
 import pytest
 
 from opera_tosca_parser.error import ParseError
-from opera_tosca_parser.parser.tosca.v_1_3.definitions.notification_implementation_definition import NotificationImplementationDefinition
+from opera_tosca_parser.parser.tosca.v_1_3.definitions.notification_implementation_definition import \
+    NotificationImplementationDefinition
 from opera_tosca_parser.parser.yaml.node import Node
 
 

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_1_3/definitions/test_operation_definition_for_template.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_1_3/definitions/test_operation_definition_for_template.py
@@ -1,7 +1,8 @@
 import pytest
 
 from opera_tosca_parser.error import ParseError
-from opera_tosca_parser.parser.tosca.v_1_3.definitions.operation_definition_for_template import OperationDefinitionForTemplate
+from opera_tosca_parser.parser.tosca.v_1_3.definitions.operation_definition_for_template import \
+    OperationDefinitionForTemplate
 from opera_tosca_parser.parser.yaml.node import Node
 
 

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_1_3/definitions/test_operation_implementation_definition.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_1_3/definitions/test_operation_implementation_definition.py
@@ -1,7 +1,8 @@
 import pytest
 
 from opera_tosca_parser.error import ParseError
-from opera_tosca_parser.parser.tosca.v_1_3.definitions.operation_implementation_definition import OperationImplementationDefinition
+from opera_tosca_parser.parser.tosca.v_1_3.definitions.operation_implementation_definition import \
+    OperationImplementationDefinition
 from opera_tosca_parser.parser.yaml.node import Node
 
 

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_1_3/test_reference.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_1_3/test_reference.py
@@ -1,9 +1,9 @@
 import pytest
 
 from opera_tosca_parser.error import ParseError
+from opera_tosca_parser.parser.tosca.v_1_3.definitions.service_template import ServiceTemplate
 from opera_tosca_parser.parser.tosca.v_1_3.reference import DataTypeReferenceWrapper, Reference, ReferenceWrapper
 from opera_tosca_parser.parser.tosca.v_1_3.type import Type
-from opera_tosca_parser.parser.tosca.v_1_3.definitions.service_template import ServiceTemplate
 from opera_tosca_parser.parser.yaml.node import Node
 
 

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_activity_definition.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_activity_definition.py
@@ -1,0 +1,68 @@
+from opera_tosca_parser.parser.tosca.v_2_0.definitions.activity_definition import ActivityDefinition
+
+
+class TestParse:
+    def test_delegate_workflow(self, yaml_ast):
+        ActivityDefinition.parse(yaml_ast(
+            # language=yaml
+            """
+            delegate:
+              workflow: delegate_workflow_name
+              inputs:
+                test_input: { get_input: [ SELF, test_input ] }
+            """
+        ))
+
+    def test_delegate_workflow_short(self, yaml_ast):
+        ActivityDefinition.parse(yaml_ast(
+            # language=yaml
+            """
+            delegate: delegate_workflow_name
+            """
+        ))
+
+    def test_set_state(self, yaml_ast):
+        ActivityDefinition.parse(yaml_ast(
+            # language=yaml
+            """
+            set_state: new_node_state
+            """
+        ))
+
+    def test_call_operation(self, yaml_ast):
+        ActivityDefinition.parse(yaml_ast(
+            # language=yaml
+            """
+            call_operation:
+              operation: my.interfaces.scaling.scale_up
+              inputs:
+                test_input: { get_input: [ SELF, test_input ] }
+            """
+        ))
+
+    def test_call_operation_short(self, yaml_ast):
+        ActivityDefinition.parse(yaml_ast(
+            # language=yaml
+            """
+            call_operation: my.interfaces.scaling.scale_up
+            """
+        ))
+
+    def test_inline_workflow(self, yaml_ast):
+        ActivityDefinition.parse(yaml_ast(
+            # language=yaml
+            """
+            inline:
+              workflow: delegate_workflow_name
+              inputs:
+                test_input: { get_input: [ SELF, test_input ] }
+            """
+        ))
+
+    def test_inline_workflow_short(self, yaml_ast):
+        ActivityDefinition.parse(yaml_ast(
+            # language=yaml
+            """
+            inline: delegate_workflow_name
+            """
+        ))

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_artifact_definition.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_artifact_definition.py
@@ -1,0 +1,53 @@
+import pytest
+
+from opera_tosca_parser.error import ParseError
+from opera_tosca_parser.parser.tosca.v_2_0.definitions.artifact_definition import ArtifactDefinition
+from opera_tosca_parser.parser.yaml.node import Node
+
+
+class TestNormalize:
+    @pytest.mark.parametrize("data", [1, 2.3, True, (), []])
+    def test_invalid_data(self, data):
+        with pytest.raises(ParseError):
+            ArtifactDefinition.normalize(Node(data))
+
+    def test_string_normalization(self):
+        obj = ArtifactDefinition.normalize(Node("string"))
+
+        assert obj.bare == {
+            "type": "File",
+            "file": "string",
+        }
+
+    def test_dict_normalization(self):
+        node = Node({})
+        obj = ArtifactDefinition.normalize(node)
+
+        assert obj == node
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        ArtifactDefinition.parse(yaml_ast(
+            # language=yaml
+            """
+            description: My arty desc
+            type: my.type
+            file: some/file
+            repository: repo reference
+            deploy_path: another/path
+            checksum: abcsdfkjrkfsdjdbhf
+            checksum_algorithm: SHA256
+            properties:
+              prop: val
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        ArtifactDefinition.parse(yaml_ast(
+            # language=yaml
+            """
+            type: my.type
+            file: some/file
+            """
+        ))

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_artifact_type.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_artifact_type.py
@@ -1,0 +1,28 @@
+from opera_tosca_parser.parser.tosca.v_2_0.definitions.artifact_type import ArtifactType
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        ArtifactType.parse(yaml_ast(
+            # language=yaml
+            """
+            derived_from: artifact_type
+            description: My desc
+            metadata:
+              key: value
+            version: "1.2"
+            mime_type: applicaton/json
+            file_ext: [ json, jsn ]
+            properties:
+              prop:
+                type: prop_type
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        ArtifactType.parse(yaml_ast(
+            # language=yaml
+            """
+            derived_from: artifact_type
+            """
+        ))

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_attribute_definition.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_attribute_definition.py
@@ -1,0 +1,21 @@
+from opera_tosca_parser.parser.tosca.v_2_0.definitions.attribute_definition import AttributeDefinition
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        AttributeDefinition.parse(yaml_ast(
+            # language=yaml
+            """
+            type: my_type
+            description: Some desc
+            default: 5
+            status: deprecated
+            key_schema:
+              type: integer
+            entry_schema:
+              type: integer
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        AttributeDefinition.parse(yaml_ast("type: my_type"))

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_capability_assignment.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_capability_assignment.py
@@ -1,0 +1,17 @@
+from opera_tosca_parser.parser.tosca.v_2_0.definitions.capability_assignment import CapabilityAssignment
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        CapabilityAssignment.parse(yaml_ast(
+            # language=yaml
+            """
+            properties:
+              prop: value
+            attributes:
+              attr: value
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        CapabilityAssignment.parse(yaml_ast("{}"))

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_capability_definition.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_capability_definition.py
@@ -1,0 +1,23 @@
+from opera_tosca_parser.parser.tosca.v_2_0.definitions.capability_definition import CapabilityDefinition
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        CapabilityDefinition.parse(yaml_ast(
+            # language=yaml
+            """
+            type: cap_type_name
+            description: Some text
+            properties: {}
+            attributes: {}
+            valid_source_node_types: []
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        CapabilityDefinition.parse(yaml_ast(
+            # language=yaml
+            """
+            type: cap_type_name
+            """
+        ))

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_capability_type.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_capability_type.py
@@ -1,0 +1,31 @@
+from opera_tosca_parser.parser.tosca.v_2_0.definitions.capability_type import CapabilityType
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        CapabilityType.parse(yaml_ast(
+            # language=yaml
+            """
+            derived_from: cap_type
+            description: My desc
+            metadata:
+              key: value
+            version: "1.2"
+            properties:
+              prop:
+                type: list
+            attributes:
+              attr:
+                type: string
+            valid_source_node_types:
+              - my_type
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        CapabilityType.parse(yaml_ast(
+            # language=yaml
+            """
+            derived_from: cap_type
+            """
+        ))

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_condition_clause_definition.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_condition_clause_definition.py
@@ -1,0 +1,199 @@
+import pytest
+
+from opera_tosca_parser.error import ParseError
+from opera_tosca_parser.parser.tosca.v_2_0.definitions.condition_clause_definition import ConditionClauseDefinition
+
+
+class TestParseValidate:
+    def test_valid_clause_direct_assertion(self, yaml_ast):
+        test_yaml = yaml_ast(
+            # language=yaml
+            """
+            my_attribute: [ { equal: 42 } ]
+            """
+        )
+        ConditionClauseDefinition.parse(test_yaml)
+        ConditionClauseDefinition.validate(test_yaml)
+
+    def test_valid_clause_direct_assertion_list(self, yaml_ast):
+        test_yaml = yaml_ast(
+            # language=yaml
+            """
+            my_attribute: [ { min_length: 1 }, { min_length: 11 } ]
+            """
+        )
+        ConditionClauseDefinition.parse(test_yaml)
+        ConditionClauseDefinition.validate(test_yaml)
+
+    def test_valid_clause_not(self, yaml_ast):
+        test_yaml = yaml_ast(
+            # language=yaml
+            """
+            not:
+              - my_attribute: [{equal: my_value}]
+              - my_other_attribute: [{equal: my_other_value}]
+            """
+        )
+        ConditionClauseDefinition.parse(test_yaml)
+        ConditionClauseDefinition.validate(test_yaml)
+
+    def test_valid_clause_and(self, yaml_ast):
+        test_yaml = yaml_ast(
+            # language=yaml
+            """
+            and:
+              - my_attribute: [{equal: my_value}]
+              - my_other_attribute: [{equal: my_other_value}]
+            """
+        )
+        ConditionClauseDefinition.parse(test_yaml)
+        ConditionClauseDefinition.validate(test_yaml)
+
+    def test_valid_clause_not_and(self, yaml_ast):
+        test_yaml = yaml_ast(
+            # language=yaml
+            """
+            not:
+              - and:
+                - my_attribute: [ { greater_than: 42 } ]
+                - my_other_attribute: [ { less_than: 1000 } ]
+            """
+        )
+        ConditionClauseDefinition.parse(test_yaml)
+        ConditionClauseDefinition.validate(test_yaml)
+
+    def test_valid_clause_or(self, yaml_ast):
+        test_yaml = yaml_ast(
+            # language=yaml
+            """
+            or:
+              - my_attribute: [{equal: my_value}]
+              - my_other_attribute: [{equal: my_other_value}]
+            """
+        )
+        ConditionClauseDefinition.parse(test_yaml)
+        ConditionClauseDefinition.validate(test_yaml)
+
+    def test_valid_clause_or_not(self, yaml_ast):
+        test_yaml = yaml_ast(
+            # language=yaml
+            """
+            or:
+              - not:
+                - my_attribute1: [{equal: value1}]
+              - not:
+                - my_attribute2: [{equal: value1}]
+            """
+        )
+        ConditionClauseDefinition.parse(test_yaml)
+        ConditionClauseDefinition.validate(test_yaml)
+
+    def test_valid_clause_or_and_not(self, yaml_ast):
+        test_yaml = yaml_ast(
+            # language=yaml
+            """
+            or:
+              - and:
+                - protocol: { equal: http }
+                - port: { equal: 80 }
+              - and:
+                - protocol: { equal: https }
+                - port: { equal: 431 }
+            """
+        )
+        ConditionClauseDefinition.parse(test_yaml)
+        ConditionClauseDefinition.validate(test_yaml)
+
+    def test_valid_clause_nested(self, yaml_ast):
+        test_yaml = yaml_ast(
+            # language=yaml
+            """
+            or:
+              - not:
+                - my_attribute1: [{equal: value1}]
+              - and:
+                - my_attribute2: { equal: value2 }
+                - and:
+                  - my_attribute3: { equal: value3 }
+                - and:
+                  - my_attribute4: { equal: value4 }
+                  - my_attribute5: { equal: value5 }
+                - or:
+                  - my_attribute6: { equal: value6 }
+                  - my_attribute7: { equal: value7 }
+                  - or:
+                    - not:
+                      - my_attribute8: { equal: value8 }
+                      - my_attribute9: { equal: value9 }
+                    - and:
+                      - not:
+                        - or:
+                          - my_attribute10: { equal: value10 }
+                        - my_attribute11: { equal: value11 }
+              - and:
+                - my_attribute12: { equal: value12 }
+                - my_attribute13: { equal: value13 }
+            """
+        )
+        ConditionClauseDefinition.parse(test_yaml)
+        ConditionClauseDefinition.validate(test_yaml)
+
+    def test_invalid_clause_not(self, yaml_ast):
+        test_yaml = yaml_ast(
+            # language=yaml
+            """
+            nott:
+              - my_attribute: [{equal: my_value}]
+              - my_other_attribute: [{equal: my_other_value}]
+            """
+        )
+        with pytest.raises(ParseError):
+            ConditionClauseDefinition.parse(test_yaml)
+            ConditionClauseDefinition.validate(test_yaml)
+
+    def test_invalid_clause_nested(self, yaml_ast):
+        test_yaml = yaml_ast(
+            # language=yaml
+            """
+            or:
+              - not:
+              - and:
+                - my_attribute2: { equals: value2 }
+                - and:
+                  - my_attribute3: { equal: value3 }
+                - and:
+                  - my_attribute4: { equal: value4 }
+                  - my_attribute5: { equal: value5 }
+                - or:
+                  - my_attribute6: { equal: value6 }
+                  - my_attribute7: { equal: value7 }
+                  - or:
+                    - not:
+                      - my_attribute8: { equal: value8 }
+                      - my_attribute9: { equal: value9 }
+                    - and:
+                      - not:
+                        - or:
+                          - my_attribute10: { equal: value10 }
+                        - my_attribute11: { equal: value11 }
+              - and:
+                - my_attribute12: { equal: value12 }
+                - my_attribute13: { equal: value13 }
+            """
+        )
+        with pytest.raises(ParseError):
+            ConditionClauseDefinition.parse(test_yaml)
+            ConditionClauseDefinition.validate(test_yaml)
+
+    def test_invalid_clause_assert(self, yaml_ast):
+        test_yaml = yaml_ast(
+            # language=yaml
+            """
+            assert:
+              - my_attribute: [{equal: my_value}]
+              - my_other_attribute: [{in_range: [1, 10]}]
+            """
+        )
+        with pytest.raises(ParseError):
+            ConditionClauseDefinition.parse(test_yaml)
+            ConditionClauseDefinition.validate(test_yaml)

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_constraint_clause.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_constraint_clause.py
@@ -1,0 +1,18 @@
+import pytest
+
+from opera_tosca_parser.error import ParseError
+from opera_tosca_parser.parser.tosca.v_2_0.definitions.constraint_clause import ConstraintClause
+
+
+class TestValidate:
+    def test_valid_clause(self, yaml_ast):
+        ConstraintClause.validate(yaml_ast("equal: 3"))
+
+    def test_invalid_clause(self, yaml_ast):
+        with pytest.raises(ParseError):
+            ConstraintClause.validate(yaml_ast("bad_operator: must fail"))
+
+
+class TestParse:
+    def test_parse(self, yaml_ast):
+        ConstraintClause.parse(yaml_ast("in_range: [ 1, 2 ]"))

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_data_type.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_data_type.py
@@ -1,0 +1,42 @@
+import pytest
+
+from opera_tosca_parser.parser.tosca.v_2_0.definitions.data_type import DataType
+from opera_tosca_parser.parser.yaml.node import Node
+
+
+class TestNormalize:
+    @pytest.mark.parametrize("data", [1, 2.3, True, (), "string"])
+    def test_ignores_non_dict_data(self, data):
+        node = Node(data)
+
+        assert DataType.normalize(node) == node
+
+    def test_ignores_dict_data_with_derived_from_key(self):
+        node = Node({Node("derived_from"): Node("integer")})
+
+        assert DataType.normalize(node) == node
+
+    def test_updates_dict_data_with_derived_from_key(self):
+        assert DataType.normalize(Node({})).bare == {"derived_from": "None"}
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        DataType.parse(yaml_ast(
+            # language=yaml
+            """
+            derived_from: data_type
+            description: My desc
+            metadata:
+              key: value
+            version: "1.4"
+            constraints:
+              - in_range: [ 1, 6 ]
+            properties:
+              prop:
+                type: map
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        DataType.parse(yaml_ast("{}"))

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_event_filter_definition.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_event_filter_definition.py
@@ -1,0 +1,21 @@
+from opera_tosca_parser.parser.tosca.v_2_0.definitions.event_filter_definition import EventFilterDefinition
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        EventFilterDefinition.parse(yaml_ast(
+            # language=yaml
+            """
+            node: node_type_name
+            requirement: requirement_name
+            capability: capability_name
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        EventFilterDefinition.parse(yaml_ast(
+            # language=yaml
+            """
+            node: node_template_name
+            """
+        ))

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_file_uri.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_file_uri.py
@@ -1,0 +1,3 @@
+class TestFileUri:
+    # TODO: Add tests.
+    pass

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_group_definition.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_group_definition.py
@@ -1,0 +1,26 @@
+from opera_tosca_parser.parser.tosca.v_2_0.definitions.group_definition import GroupDefinition
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        GroupDefinition.parse(yaml_ast(
+            # language=yaml
+            """
+            type: node.type
+            description: Text
+            metadata: {}
+            properties: {}
+            members:
+              - node_template_1
+              - node_template_2
+              - node_template_3
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        GroupDefinition.parse(yaml_ast(
+            # language=yaml
+            """
+            type: group.type
+            """
+        ))

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_group_type.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_group_type.py
@@ -1,0 +1,26 @@
+from opera_tosca_parser.parser.tosca.v_2_0.definitions.group_type import GroupType
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        GroupType.parse(yaml_ast(
+            # language=yaml
+            """
+            derived_from: group_type
+            description: My desc
+            metadata:
+              key: value
+            version: "1.2"
+            attributes: {}
+            properties: {}
+            members: [node_type_a, node_type_b, node_type_c]
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        GroupType.parse(yaml_ast(
+            # language=yaml
+            """
+            derived_from: group_type
+            """
+        ))

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_import_definition.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_import_definition.py
@@ -1,0 +1,48 @@
+import pytest
+
+from opera_tosca_parser.error import ParseError
+from opera_tosca_parser.parser.tosca.v_2_0.definitions.import_definition import ImportDefinition
+from opera_tosca_parser.parser.yaml.node import Node
+
+
+class TestNormalizeDefinition:
+    def test_noop_for_dicts(self):
+        node = Node({})
+        assert ImportDefinition.normalize(node) == node
+
+    def test_string_normalization(self):
+        assert ImportDefinition.normalize(Node("a")).bare == {"url": "a"}
+
+    @pytest.mark.parametrize("data", [123, 1.4, []])
+    def test_failed_normalization(self, data):
+        with pytest.raises(ParseError, match="string or dict"):
+            ImportDefinition.normalize(Node(data))
+
+
+class TestParse:
+    def test_full_url(self, yaml_ast):
+        ImportDefinition.parse(yaml_ast(
+            # language=yaml
+            """
+            url: my/file
+            repository: my_repo
+            namespace: prefix
+            """
+        ))
+
+    def test_full_profile(self, yaml_ast):
+        ImportDefinition.parse(yaml_ast(
+            # language=yaml
+            """
+            profile: my_profile
+            namespace: prefix
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        ImportDefinition.parse(yaml_ast(
+            # language=yaml
+            """
+            url: my/file
+            """
+        ))

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_interface_assignment.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_interface_assignment.py
@@ -1,0 +1,21 @@
+from opera_tosca_parser.parser.tosca.v_2_0.definitions.interface_assignment import InterfaceAssignment
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        InterfaceAssignment.parse(yaml_ast(
+            # language=yaml
+            """
+            inputs:
+              in: put
+            operations:
+              op: artifact
+            notifications:
+              my_notification:
+                implementation:
+                    primary: primary_artifact_definition
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        InterfaceAssignment.parse(yaml_ast("{}"))

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_interface_definition.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_interface_definition.py
@@ -1,0 +1,16 @@
+from opera_tosca_parser.parser.tosca.v_2_0.definitions.interface_definition import InterfaceDefinition
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        InterfaceDefinition.parse(yaml_ast(
+            # language=yaml
+            """
+            inputs: {}
+            operations: {}
+            notifications: {}
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        InterfaceDefinition.parse(yaml_ast("{}"))

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_interface_type.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_interface_type.py
@@ -1,0 +1,28 @@
+from opera_tosca_parser.parser.tosca.v_2_0.definitions.interface_type import InterfaceType
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        InterfaceType.parse(yaml_ast(
+            # language=yaml
+            """
+            derived_from: interface_type
+            description: My desc
+            metadata:
+              key: value
+            version: "1.2"
+            inputs:
+              in:
+                type: float
+            operations: {}
+            notifications: {}
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        InterfaceType.parse(yaml_ast(
+            # language=yaml
+            """
+            derived_from: interface_type
+            """
+        ))

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_node_filter_definition.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_node_filter_definition.py
@@ -1,0 +1,16 @@
+from opera_tosca_parser.parser.tosca.v_2_0.definitions.node_filter_definition import NodeFilterDefinition
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        NodeFilterDefinition.parse(yaml_ast(
+            # language=yaml
+            """
+            properties:
+              - num_cpus: { in_range: [ 3, 6 ] }
+            capabilities: []
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        NodeFilterDefinition.parse(yaml_ast("{}"))

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_node_template.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_node_template.py
@@ -1,0 +1,30 @@
+from opera_tosca_parser.parser.tosca.v_2_0.definitions.node_template import NodeTemplate
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        NodeTemplate.parse(yaml_ast(
+            # language=yaml
+            """
+            type: node.type
+            description: Text
+            metadata: {}
+            directives: []
+            properties: {}
+            attributes: {}
+            requirements: []
+            capabilities: {}
+            interfaces: {}
+            artifacts: {}
+            node_filter: {}
+            copy: template_name
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        NodeTemplate.parse(yaml_ast(
+            # language=yaml
+            """
+            type: node.type
+            """
+        ))

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_node_type.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_node_type.py
@@ -1,0 +1,31 @@
+from opera_tosca_parser.parser.tosca.v_2_0.definitions.node_type import NodeType
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        NodeType.parse(yaml_ast(
+            # language=yaml
+            """
+            derived_from: node_type
+            description: My desc
+            metadata:
+              key: value
+            version: "1.2"
+            attributes: {}
+            properties: {}
+            requirements:
+              - first: requirement_cap_name
+              - second:
+                  capability: type_name
+            interfaces: {}
+            artifacts: {}
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        NodeType.parse(yaml_ast(
+            # language=yaml
+            """
+            derived_from: node_type
+            """
+        ))

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_notification_definition.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_notification_definition.py
@@ -1,0 +1,17 @@
+from opera_tosca_parser.parser.tosca.v_2_0.definitions.notification_definition import NotificationDefinition
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        NotificationDefinition.parse(yaml_ast(
+            # language=yaml
+            """
+            description: Bla bla bla
+            implementation: path/to/artifact
+            outputs:
+              data: [ SELF, attribute ]
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        NotificationDefinition.parse(yaml_ast("{}"))

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_notification_implementation_definition.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_notification_implementation_definition.py
@@ -1,0 +1,39 @@
+import pytest
+
+from opera_tosca_parser.error import ParseError
+from opera_tosca_parser.parser.tosca.v_2_0.definitions.notification_implementation_definition import \
+    NotificationImplementationDefinition
+from opera_tosca_parser.parser.yaml.node import Node
+
+
+class TestNormalize:
+    @pytest.mark.parametrize("data", [1, 2.3, True, (), []])
+    def test_invalid_data(self, data):
+        with pytest.raises(ParseError):
+            NotificationImplementationDefinition.normalize(Node(data))
+
+    def test_string_normalization(self):
+        obj = NotificationImplementationDefinition.normalize(Node("string"))
+
+        assert obj.bare == {"primary": "string"}
+
+    def test_dict_normalization(self):
+        node = Node({})
+        obj = NotificationImplementationDefinition.normalize(node)
+
+        assert obj == node
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        NotificationImplementationDefinition.parse(yaml_ast(
+            # language=yaml
+            """
+            primary: first
+            dependencies:
+              - second
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        NotificationImplementationDefinition.parse(yaml_ast("first"))

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_operation_assignment.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_operation_assignment.py
@@ -1,0 +1,40 @@
+import pytest
+
+from opera_tosca_parser.error import ParseError
+from opera_tosca_parser.parser.tosca.v_2_0.definitions.operation_assignment import OperationAssignment
+from opera_tosca_parser.parser.yaml.node import Node
+
+
+class TestNormalize:
+    @pytest.mark.parametrize("data", [1, 2.3, True, (), []])
+    def test_invalid_data(self, data):
+        with pytest.raises(ParseError):
+            OperationAssignment.normalize(Node(data))
+
+    def test_string_normalization(self):
+        obj = OperationAssignment.normalize(Node("string"))
+
+        assert obj.bare == {"implementation": "string"}
+
+    def test_dict_normalization(self):
+        node = Node({})
+        obj = OperationAssignment.normalize(node)
+
+        assert obj == node
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        OperationAssignment.parse(yaml_ast(
+            # language=yaml
+            """
+            implementation: path/to/artifact
+            inputs:
+              my_input: value
+            outputs:
+              my_output: [ SELF, attribute_name ]
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        OperationAssignment.parse(yaml_ast("{}"))

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_operation_definition.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_operation_definition.py
@@ -1,0 +1,42 @@
+import pytest
+
+from opera_tosca_parser.error import ParseError
+from opera_tosca_parser.parser.tosca.v_2_0.definitions.operation_definition import OperationDefinition
+from opera_tosca_parser.parser.yaml.node import Node
+
+
+class TestNormalize:
+    @pytest.mark.parametrize("data", [1, 2.3, True, (), []])
+    def test_invalid_data(self, data):
+        with pytest.raises(ParseError):
+            OperationDefinition.normalize(Node(data))
+
+    def test_string_normalization(self):
+        obj = OperationDefinition.normalize(Node("string"))
+
+        assert obj.bare == {"implementation": "string"}
+
+    def test_dict_normalization(self):
+        node = Node({})
+        obj = OperationDefinition.normalize(node)
+
+        assert obj == node
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        OperationDefinition.parse(yaml_ast(
+            # language=yaml
+            """
+            description: Some description
+            implementation: bla
+            inputs:
+              input:
+                type: string
+            outputs:
+              my_output: [ SELF, attribute_name ]
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        OperationDefinition.parse(yaml_ast("{}"))

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_operation_host.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_operation_host.py
@@ -1,0 +1,20 @@
+import pytest
+
+from opera_tosca_parser.error import ParseError
+from opera_tosca_parser.parser.tosca.v_2_0.definitions.operation_host import OperationHost
+from opera_tosca_parser.parser.yaml.node import Node
+
+
+class TestValidate:
+    @pytest.mark.parametrize(
+        "version", ["SELF", "SOURCE", "TARGET", "ORCHESTRATOR"]
+    )
+    def test_valid_tosca_versions(self, version):
+        OperationHost.validate(Node(version))
+
+    @pytest.mark.parametrize(
+        "version", ["", "  ", "a", "tosca_2_0", 123, "abc", {}, []]
+    )
+    def test_invalid_tosca_versions(self, version):
+        with pytest.raises(ParseError):
+            OperationHost.validate(Node(version))

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_operation_implementation_definition.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_operation_implementation_definition.py
@@ -1,0 +1,41 @@
+import pytest
+
+from opera_tosca_parser.error import ParseError
+from opera_tosca_parser.parser.tosca.v_2_0.definitions.operation_implementation_definition import \
+    OperationImplementationDefinition
+from opera_tosca_parser.parser.yaml.node import Node
+
+
+class TestNormalize:
+    @pytest.mark.parametrize("data", [1, 2.3, True, (), []])
+    def test_invalid_data(self, data):
+        with pytest.raises(ParseError):
+            OperationImplementationDefinition.normalize(Node(data))
+
+    def test_string_normalization(self):
+        obj = OperationImplementationDefinition.normalize(Node("string"))
+
+        assert obj.bare == {"primary": "string"}
+
+    def test_dict_normalization(self):
+        node = Node({})
+        obj = OperationImplementationDefinition.normalize(node)
+
+        assert obj == node
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        OperationImplementationDefinition.parse(yaml_ast(
+            # language=yaml
+            """
+            primary: artifact
+            dependencies:
+              - first
+              - second
+            timeout: 4
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        OperationImplementationDefinition.parse(yaml_ast("{}"))

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_parameter_definition.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_parameter_definition.py
@@ -1,0 +1,26 @@
+from opera_tosca_parser.parser.tosca.v_2_0.definitions.parameter_definition import ParameterDefinition
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        ParameterDefinition.parse(yaml_ast(
+            # language=yaml
+            """
+            type: data_type_name
+            description: My text
+            required: true
+            default: 567
+            status: supported
+            constraints: []
+            key_schema:
+              type: string
+            entry_schema:
+              type: timestamp
+            external_schema: schema
+            metadata: {}
+            value: 987
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        ParameterDefinition.parse(yaml_ast("{}"))

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_policy_definition.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_policy_definition.py
@@ -1,0 +1,33 @@
+from opera_tosca_parser.parser.tosca.v_2_0.definitions.policy_definition import PolicyDefinition
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        PolicyDefinition.parse(yaml_ast(
+            # language=yaml
+            """
+            type: policy.type
+            description: Some muttering
+            metadata: {}
+            properties:
+              prop: 6.7
+            targets: [node_type_a, node_type_b, node_type_c]
+            triggers:
+              my_first_trigger:
+                event: my_first_trigger
+                action:
+                  - call_operation: test.interfaces.Test1.test2
+              my_second_trigger:
+                event: my_second_trigger
+                action:
+                  - call_operation: test.interfaces.Test2.test1
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        PolicyDefinition.parse(yaml_ast(
+            # language=yaml
+            """
+            type: policy.type
+            """
+        ))

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_policy_type.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_policy_type.py
@@ -1,0 +1,51 @@
+from opera_tosca_parser.parser.tosca.v_2_0.definitions.policy_type import PolicyType
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        PolicyType.parse(yaml_ast(
+            # language=yaml
+            """
+            derived_from: policy_type
+            description: My desc
+            metadata:
+              key: value
+            version: "1.2"
+            properties: {}
+            targets: [ node_type, group_type ]
+            triggers:
+              my_trigger:
+                description: A trigger
+                event: my_trigger
+                target_filter:
+                  node: node
+                  requirement: my_requirement
+                  capability: my_capability
+                condition:
+                  constraint:
+                    - not:
+                      - and:
+                        - my_attribute: [ in_range: [1, 50] ]
+                        - my_other_attribute: [ equal: my_other_value ]
+                  period: 60 sec
+                  evaluations: 2
+                  method: average
+                action:
+                  - call_operation:
+                      operation: test.interfaces.test.Test.test
+                      inputs:
+                        test_input: { get_property: [ SELF, test_property ] }
+                  - delegate:
+                      workflow: delegate_workflow_name
+                      inputs:
+                        test_input: { get_input: [ SELF, test_input ] }
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        PolicyType.parse(yaml_ast(
+            # language=yaml
+            """
+            derived_from: policy_type
+            """
+        ))

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_property_definition.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_property_definition.py
@@ -1,0 +1,30 @@
+from opera_tosca_parser.parser.tosca.v_2_0.definitions.property_definition import PropertyDefinition
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        PropertyDefinition.parse(yaml_ast(
+            # language=yaml
+            """
+            type: map
+            description: My description
+            required: false
+            default: { a: 3 }
+            status: supported
+            constraints: []
+            key_schema:
+              type: string
+            entry_schema:
+              type: integer
+            external_schema: some schema
+            metadata: {}
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        PropertyDefinition.parse(yaml_ast(
+            # language=yaml
+            """
+            type: map
+            """
+        ))

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_range.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_range.py
@@ -1,0 +1,33 @@
+import math
+
+import pytest
+
+from opera_tosca_parser.error import ParseError
+from opera_tosca_parser.parser.tosca.v_2_0.definitions.range import Range
+
+
+class TestValidate:
+    @pytest.mark.parametrize("data", ["[1, 2]", "[3, UNBOUNDED]", "- 3\n- 6"])
+    def test_with_valid_data(self, data, yaml_ast):
+        Range.validate(yaml_ast(data))
+
+    @pytest.mark.parametrize("data", [
+        "abc", "4", "{}", "3.4", "false", "null",  # Invalid types
+        "[]", "[1]", "[1, 2, 3]", "[1, 2, 3, 4]",  # Invalid cardinality
+        "[a, 1]", "[2.3, 1]", "[false, 1]", "[null, 1]",  # Invalid lo type
+        "[0, 1.3]", "[0, true]", "[0, null]", "[0, {}]",  # Invalid hi type
+        "[0, a]", "[0, \"\"]", "[0, BAD]",  # Invalid hi string
+        "[5, 2]", "[-3, -6]", "[4, -3]",  # lo > hi
+    ])
+    def test_invalid_data(self, data, yaml_ast):
+        with pytest.raises(ParseError):
+            Range.validate(yaml_ast(data))
+
+
+class TestBuild:
+    @pytest.mark.parametrize("input_string,output", [
+        ("[1, 2]", (1, 2)), ("[-4, 5]", (-4, 5)),
+        ("[0, UNBOUNDED]", (0, math.inf)),
+    ])
+    def test_construction(self, input_string, output, yaml_ast):
+        assert Range.build(yaml_ast(input_string)).data == output

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_relationship_template.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_relationship_template.py
@@ -1,0 +1,30 @@
+from opera_tosca_parser.parser.tosca.v_2_0.definitions.relationship_template import RelationshipTemplate
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        RelationshipTemplate.parse(yaml_ast(
+            # language=yaml
+            """
+            type: rel.type
+            description: Some muttering
+            metadata: {}
+            properties:
+              prop: 4
+            attributes:
+              attr: 6
+            interfaces:
+              Standard:
+                operations:
+                  create: path/to/playbook.yaml
+            copy: other_template_name
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        RelationshipTemplate.parse(yaml_ast(
+            # language=yaml
+            """
+            type: rel.type
+            """
+        ))

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_relationship_type.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_relationship_type.py
@@ -1,0 +1,27 @@
+from opera_tosca_parser.parser.tosca.v_2_0.definitions.relationship_type import RelationshipType
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        RelationshipType.parse(yaml_ast(
+            # language=yaml
+            """
+            derived_from: relationship_type
+            description: My desc
+            metadata:
+              key: value
+            version: "1.2"
+            properties: {}
+            attributes: {}
+            interfaces: {}
+            valid_capability_types: [ a, b, c ]
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        RelationshipType.parse(yaml_ast(
+            # language=yaml
+            """
+            derived_from: relationship_type
+            """
+        ))

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_repository_definition.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_repository_definition.py
@@ -1,0 +1,38 @@
+import pytest
+
+from opera_tosca_parser.error import ParseError
+from opera_tosca_parser.parser.tosca.v_2_0.definitions.repository_definition import RepositoryDefinition
+from opera_tosca_parser.parser.yaml.node import Node
+
+
+class TestNormalize:
+    def test_noop_for_dicts(self):
+        node = Node({})
+        assert RepositoryDefinition.normalize(node) == node
+
+    def test_string_normalization(self):
+        assert RepositoryDefinition.normalize(Node("a")).bare == {"url": "a"}
+
+    @pytest.mark.parametrize("data", [123, 1.4, []])
+    def test_failed_normalization(self, data):
+        with pytest.raises(ParseError, match="string or dict"):
+            RepositoryDefinition.normalize(Node(data))
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        RepositoryDefinition.parse(yaml_ast(
+            # language=yaml
+            """
+            description: My description
+            url: https://repo.name
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        RepositoryDefinition.parse(yaml_ast(
+            # language=yaml
+            """
+            url: https://repo.name
+            """
+        ))

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_requirement_assignment.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_requirement_assignment.py
@@ -1,0 +1,45 @@
+import pytest
+
+from opera_tosca_parser.error import ParseError
+from opera_tosca_parser.parser.tosca.v_2_0.definitions.requirement_assignment import RequirementAssignment
+from opera_tosca_parser.parser.yaml.node import Node
+
+
+class TestNormalize:
+    @pytest.mark.parametrize("data", [1, 2.3, True, (), []])
+    def test_invalid_data(self, data):
+        with pytest.raises(ParseError):
+            RequirementAssignment.normalize(Node(data))
+
+    def test_string_normalization(self):
+        obj = RequirementAssignment.normalize(Node("string"))
+
+        assert obj.bare == {"node": "string"}
+
+    def test_dict_normalization(self):
+        node = Node({})
+        obj = RequirementAssignment.normalize(node)
+
+        assert obj == node
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        RequirementAssignment.parse(yaml_ast(
+            # language=yaml
+            """
+            capability: my_cap
+            node: some_node_template
+            relationship: some_relationship_template
+            node_filter: {}
+            count: 2
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        RequirementAssignment.parse(yaml_ast(
+            # language=yaml
+            """
+            some_node_template
+            """
+        ))

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_requirement_definition.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_requirement_definition.py
@@ -1,0 +1,44 @@
+import pytest
+
+from opera_tosca_parser.error import ParseError
+from opera_tosca_parser.parser.tosca.v_2_0.definitions.requirement_definition import RequirementDefinition
+from opera_tosca_parser.parser.yaml.node import Node
+
+
+class TestNormalize:
+    @pytest.mark.parametrize("data", [1, 2.3, True, (), []])
+    def test_invalid_data(self, data):
+        with pytest.raises(ParseError):
+            RequirementDefinition.normalize(Node(data))
+
+    def test_string_normalization(self):
+        obj = RequirementDefinition.normalize(Node("string"))
+
+        assert obj.bare == {"capability": "string"}
+
+    def test_dict_normalization(self):
+        node = Node({})
+        obj = RequirementDefinition.normalize(node)
+
+        assert obj == node
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        RequirementDefinition.parse(yaml_ast(
+            # language=yaml
+            """
+            capability: my_cap_type
+            node: my_node_type
+            relationship: my_rel_type
+            count_range: [ 2, 5 ]
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        RequirementDefinition.parse(yaml_ast(
+            # language=yaml
+            """
+            capability: my_cap_type
+            """
+        ))

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_schema_definition.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_schema_definition.py
@@ -1,0 +1,21 @@
+from opera_tosca_parser.parser.tosca.v_2_0.definitions.schema_definition import SchemaDefinition
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        SchemaDefinition.parse(yaml_ast(
+            # language=yaml
+            """
+            type: my_type
+            description: My description
+            constraints: []
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        SchemaDefinition.parse(yaml_ast(
+            # language=yaml
+            """
+            type: my_type
+            """
+        ))

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_service_template.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_service_template.py
@@ -1,0 +1,126 @@
+import pytest
+
+from opera_tosca_parser.error import ParseError
+from opera_tosca_parser.parser.tosca.v_2_0.definitions.service_template import ServiceTemplate
+from opera_tosca_parser.parser.yaml.node import Node
+
+
+class TestNormalizeDefinition:
+    def test_noop_for_dicts_with_no_dsl_definitions(self):
+        assert ServiceTemplate.normalize(Node({})).bare == {}
+
+    def test_dsl_definitions_removal(self):
+        assert ServiceTemplate.normalize(Node({Node("dsl_definitions"): "data"})).bare == {}
+
+    @pytest.mark.parametrize("data", [123, 1.4, []])
+    def test_failure_with_non_dict_data(self, data):
+        with pytest.raises(ParseError):
+            ServiceTemplate.normalize(Node(data))
+
+
+class TestParse:
+    def test_full(self, yaml_ast, tmp_path):
+        ServiceTemplate.parse_service_template(yaml_ast(
+            # language=yaml
+            """
+            tosca_definitions_version: tosca_2_0
+            profile: my_profile
+            metadata: {}
+            description: Text here
+            dsl_definitions:
+              arbitrary_data: can
+              be: here
+              since:
+                - it
+                - is
+                - stripped: from
+                  the: doc
+            repositories: {}
+            imports: []
+            artifact_types: {}
+            data_types: {}
+            capability_types: {}
+            interface_types: {}
+            relationship_types: {}
+            node_types: {}
+            group_types: {}
+            policy_types: {}
+            topology_template: {}
+            """
+        ), tmp_path, tmp_path, set())
+
+    def test_minimal(self, yaml_ast, tmp_path):
+        ServiceTemplate.parse_service_template(yaml_ast(
+            # language=yaml
+            """
+            tosca_definitions_version: tosca_2_0
+            """
+        ), tmp_path, tmp_path, set())
+
+
+class TestMerge:
+    def test_valid_section_merge(self, yaml_ast, tmp_path):
+        template = ServiceTemplate.parse_service_template(yaml_ast(
+            # language=yaml
+            """
+            tosca_definitions_version: tosca_2_0
+            node_types:
+              type_a:
+                derived_from: a
+            """
+        ), tmp_path, tmp_path, set())[0]
+        template.merge(ServiceTemplate.parse_service_template(yaml_ast(
+            # language=yaml
+            """
+            tosca_definitions_version: tosca_2_0
+            node_types:
+              type_b:
+                derived_from: b
+            """
+        ), tmp_path, tmp_path, set())[0])
+
+        assert len(template.node_types.data) == 2
+        assert template.node_types["type_a"].data["derived_from"].data == "a"
+        assert template.node_types["type_b"].data["derived_from"].data == "b"
+
+    def test_valid_merge(self, yaml_ast, tmp_path):
+        template = ServiceTemplate.parse_service_template(yaml_ast(
+            """
+            tosca_definitions_version: tosca_2_0
+            data_types:
+              type_a:
+                derived_from: a
+            """
+        ), tmp_path, tmp_path, set())[0]
+        template.merge(ServiceTemplate.parse_service_template(yaml_ast(
+            # language=yaml
+            """
+            tosca_definitions_version: tosca_2_0
+            node_types:
+              type_a:
+                derived_from: a
+            """
+        ), tmp_path, tmp_path, set())[0])
+
+        assert len(template.data_types.data) == 1
+        assert template.node_types["type_a"].data["derived_from"].data == "a"
+
+    def test_duplicates(self, yaml_ast, tmp_path):
+        with pytest.raises(ParseError, match="type_a"):
+            ServiceTemplate.parse_service_template(yaml_ast(
+                # language=yaml
+                """
+                tosca_definitions_version: tosca_2_0
+                node_types:
+                  type_a:
+                    derived_from: a
+                """
+            ), tmp_path, tmp_path, set())[0].merge(ServiceTemplate.parse_service_template(yaml_ast(
+                # language=yaml
+                """
+                tosca_definitions_version: tosca_2_0
+                node_types:
+                  type_a:
+                    derived_from: b
+                """
+            ), tmp_path, tmp_path, set())[0])

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_status.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_status.py
@@ -1,0 +1,16 @@
+import pytest
+
+from opera_tosca_parser.error import ParseError
+from opera_tosca_parser.parser.tosca.v_2_0.definitions.status import Status
+from opera_tosca_parser.parser.yaml.node import Node
+
+
+class TestValidate:
+    @pytest.mark.parametrize("status", ["supported", "unsupported", "experimental", "deprecated"])
+    def test_valid_status(self, status):
+        Status.validate(Node(status))
+
+    @pytest.mark.parametrize("status", ["some", "random", "stuff", 1, 2, [], {}, (), 1.2, False])
+    def test_invalid_status(self, status):
+        with pytest.raises(ParseError):
+            Status.validate(Node(status))

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_topology_template.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_topology_template.py
@@ -1,0 +1,33 @@
+from opera_tosca_parser.parser.tosca.v_2_0.definitions.topology_template import TopologyTemplate
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        TopologyTemplate.parse(yaml_ast(
+            # language=yaml
+            """
+            description: Topology description
+            inputs:
+              my_input:
+                type: float
+                value: 14.3
+            node_templates:
+              my_node_template:
+                type: node.type
+            relationship_templates:
+              my_rel_template:
+                type: rel.type
+            groups:
+              my_group:
+                type: group.type
+            policies:
+              - my_policy:
+                  type: policy.type
+            outputs:
+              my_output:
+                type: string
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        TopologyTemplate.parse(yaml_ast("{}"))

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_tosca_definitions_version.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_tosca_definitions_version.py
@@ -1,0 +1,22 @@
+import pytest
+
+from opera_tosca_parser.error import ParseError
+from opera_tosca_parser.parser.tosca.v_2_0.definitions.tosca_definitions_version import ToscaDefinitionsVersion
+from opera_tosca_parser.parser.yaml.node import Node
+
+
+class TestValidate:
+    def test_valid_tosca_versions(self):
+        ToscaDefinitionsVersion.validate(Node("tosca_2_0"))
+
+    @pytest.mark.parametrize(
+        "version", [
+            "", "  ", "a", "tosca_simple_yaml_1_4", 123, "abc", {}, [],
+            "tosca_simple_yaml_1_4", "tosca_simple_yaml_2", "tosca_yaml_1_2",
+            "tosca_simple_yaml_1_0", "tosca_simple_yaml_1_1",
+            "tosca_simple_yaml_1_2",
+        ],
+    )
+    def test_invalid_tosca_versions(self, version):
+        with pytest.raises(ParseError):
+            ToscaDefinitionsVersion.validate(Node(version))

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_trigger_definition.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/definitions/test_trigger_definition.py
@@ -1,0 +1,38 @@
+from opera_tosca_parser.parser.tosca.v_2_0.definitions.trigger_definition import TriggerDefinition
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        TriggerDefinition.parse(yaml_ast(
+            # language=yaml
+            """
+            description: A trigger
+            event: trigger
+            target_filter:
+              node: node
+              requirement: my_requirement
+              capability: my_capability
+            condition:
+              constraint:
+                - not:
+                  - and:
+                    - my_attribute: [{equal: my_value}]
+                    - my_other_attribute: [{equal: my_other_value}]
+              period: 60 sec
+              evaluations: 2
+              method: average
+            action:
+              - call_operation: test.interfaces.Update.update
+              - call_operation: test.interfaces.Upgrade.upgrade
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        TriggerDefinition.parse(yaml_ast(
+            # language=yaml
+            """
+            event: trigger
+            action:
+              - call_operation: test.interfaces.Test.test
+            """
+        ))

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/test_base.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/test_base.py
@@ -1,0 +1,76 @@
+from unittest.mock import Mock
+
+import pytest
+
+from opera_tosca_parser.error import ParseError
+from opera_tosca_parser.parser.tosca.v_2_0.base import Base
+from opera_tosca_parser.parser.utils.location import Location
+from opera_tosca_parser.parser.yaml.node import Node
+
+
+class TestParse:
+    @pytest.mark.parametrize("data", ["", 4, "a", (), (1, 2, 3)])
+    def test_creates_new_instance(self, data):
+        obj = Base.parse(Node(data, Location("s", 1, 2)))
+
+        assert obj.data == data
+        assert obj.loc.stream_name == "s"
+        assert obj.loc.line == 1
+        assert obj.loc.column == 2
+
+
+class TestNormalize:
+    @pytest.mark.parametrize(
+        "data", ["", 4, "a", (), (1, 2, 3), [], ["a", "b"]],
+    )
+    def test_normalize_is_noop(self, data):
+        assert Base.normalize(data) == data
+
+
+class TestValidate:
+    @pytest.mark.parametrize(
+        "data", ["", 4, "a", (), (1, 2, 3), [], ["a", "b"]],
+    )
+    def test_validate_is_always_ok(self, data):
+        Base.validate(data)
+
+
+class TestBuild:
+    @pytest.mark.parametrize("data", ["", 4, "a", (), (1, 2, 3)])
+    def test_build_creates_new_instance(self, data):
+        obj = Base.build(Node(data, Location("stream", 1, 2)))
+
+        assert obj.data == data
+        assert obj.loc.stream_name == "stream"
+        assert obj.loc.line == 1
+        assert obj.loc.column == 2
+
+
+class TestAbort:
+    def test_abort(self):
+        with pytest.raises(ParseError, match="Error MsG"):
+            Base.abort("Error MsG", None)
+
+
+class TestStr:
+    @pytest.mark.parametrize("data", [1, 2.3, True, "abc", {}, []])
+    def test_str(self, data):
+        assert str(data) == str(Base(data, Location("s", 4, 5)))
+
+
+class TestVisit:
+    def test_nop_visit(self):
+        obj = Base(None, None)
+        obj.not_called = Mock()
+
+        obj.visit("missing_method")
+
+        obj.not_called.assert_not_called()
+
+    def test_visit(self):
+        obj = Base(None, None)
+        obj.called = Mock()
+
+        obj.visit("called", "with", keyword="args")
+
+        obj.called.assert_called_once_with("with", keyword="args")

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/test_bool.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/test_bool.py
@@ -1,0 +1,18 @@
+import pytest
+
+from opera_tosca_parser.error import ParseError
+from opera_tosca_parser.parser.tosca.v_2_0.bool import Bool
+from opera_tosca_parser.parser.yaml.node import Node
+
+
+class TestValidate:
+    @pytest.mark.parametrize("data", [True, False])
+    def test_with_bool_data(self, data):
+        Bool.validate(Node(data))
+
+    @pytest.mark.parametrize(
+        "data", [4, (), (1, 2, 3), [], ["a", "b"], {}],
+    )
+    def test_with_non_bool_data(self, data):
+        with pytest.raises(ParseError):
+            Bool.validate(Node(data))

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/test_comparable.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/test_comparable.py
@@ -1,0 +1,19 @@
+import pytest
+
+from opera_tosca_parser.parser.tosca.v_2_0.comparable import Comparable
+
+
+class TestEquality:
+    @pytest.mark.parametrize("data", [1, 2.3, "abc", (), [], {}])
+    def test_ok(self, data):
+        assert Comparable(data, None) == Comparable(data, None)
+
+    @pytest.mark.parametrize("data", [1, 2.3, "abc", (), [], {}])
+    def test_not_ok(self, data):
+        assert Comparable(data, None) != Comparable("NOT EQUAL", None)
+
+
+class TestHash:
+    @pytest.mark.parametrize("data", [1, 2.3, "abc", ()])
+    def test_ok(self, data):
+        assert hash(Comparable(data, None)) == hash(Comparable(data, None))

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/test_entity.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/test_entity.py
@@ -1,0 +1,162 @@
+import pytest
+
+from opera_tosca_parser.error import ParseError
+from opera_tosca_parser.parser.tosca.v_2_0.base import Base
+from opera_tosca_parser.parser.tosca.v_2_0.entity import Entity, TypeEntity
+from opera_tosca_parser.parser.tosca.v_2_0.reference import Reference
+from opera_tosca_parser.parser.yaml.node import Node
+
+
+class DummyAttr(Base):
+    pass
+
+
+class DummyEntity(Entity):
+    ATTRS = dict(
+        required=DummyAttr,
+        optional=DummyAttr,
+    )
+    REQUIRED = {"required"}
+
+
+class TestEntityValidate:
+    @pytest.mark.parametrize("data", [1, 3.4, "", "a", (), []])
+    def test_non_dict_data_is_invalid(self, data):
+        with pytest.raises(ParseError):
+            DummyEntity.validate(Node(data))
+
+    @pytest.mark.parametrize("key", [1, 3.4, False, None, (), []])
+    def test_non_string_keys_are_invalid(self, key):
+        with pytest.raises(ParseError):
+            DummyEntity.validate(Node(key))
+
+    def test_non_declared_attrs_fail(self):
+        with pytest.raises(ParseError, match="non_declared_attr"):
+            DummyEntity.validate(Node({
+                Node("required"): Node("value"),
+                Node("non_declared_attr"): Node(3),
+            }))
+
+    def test_required_attrs(self):
+        with pytest.raises(ParseError, match="required"):
+            DummyEntity.validate(Node({}))
+
+    def test_ok_if_optional_is_missing(self):
+        DummyEntity.validate(Node({
+            Node("required"): Node("value"),
+        }))
+
+
+class TestEntityBuild:
+    def test_build_attrs(self):
+        obj = DummyEntity.build(Node({
+            Node("required"): Node(3),
+            Node("optional"): Node(2),
+        }))
+
+        assert isinstance(obj, DummyEntity)
+        assert isinstance(obj.data["required"], DummyAttr)
+        assert isinstance(obj.data["optional"], DummyAttr)
+
+
+class TestEntityAttrs:
+    def test_attrs(self):
+        assert DummyEntity.attrs() == DummyEntity.ATTRS
+
+
+class TestEntityGetattr:
+    def test_get_valid_attr(self):
+        assert Entity(dict(a=2), None).a == 2
+
+    def test_get_invalid_attr(self):
+        with pytest.raises(AttributeError):
+            Entity(dict(a=2), None).b
+
+
+class TestEntityGetitem:
+    def test_get_valid_item(self):
+        assert Entity(dict(a=2), None)["a"] == 2
+
+    def test_get_invalid_item(self):
+        with pytest.raises(KeyError):
+            Entity(dict(a=2), None)["b"]
+
+
+class TestEntityIteration:
+    def test_iteration(self):
+        assert set(Entity(dict(a=1, b=2, c="d"), None)) == {"a", "b", "c"}
+
+
+class TestEntityDig:
+    def test_dig_through_dict(self):
+        obj = Entity({
+            "a": 1,
+            "b": 2,
+            "c": Entity({
+                "d": 6,
+                "e": 7,
+            }, None),
+        }, None)
+
+        assert obj.dig("a") == 1
+        assert obj.dig("c", "d") == 6
+
+    def test_dig_for_missing_key(self):
+        obj = Entity({
+            "a": 1,
+            "b": 2,
+            "c": Entity({
+                "d": 6,
+                "e": 7,
+            }, None),
+        }, None)
+
+        assert obj.dig("k") is None
+        assert obj.dig("c", "k") is None
+
+
+class TestEntityItems:
+    def test_items(self):
+        obj = Entity(dict(a=1, b=2), None)
+
+        assert {("a", 1), ("b", 2)} == set(obj.items())
+
+
+class TestEntityValues:
+    def test_values(self):
+        obj = DummyEntity(dict(a=1, b=2, c=3), None)
+
+        assert {1, 2, 3} == set(obj.values())
+
+
+class Goodie(TypeEntity):
+    REFERENCE = Reference("path")
+    ATTRS = dict(dummy=Base)
+
+
+class Baddie(TypeEntity):
+    ATTRS = dict(dummy=Base)
+
+
+class TestTypeEntityValidate:
+    def test_valid_data(self, yaml_ast):
+        Goodie.validate(yaml_ast(
+            # language=yaml
+            """
+            derived_from: my_parent_type
+            description: My type description
+            metadata: {}
+            version: 1.2.3.go-4
+            """
+        ))
+
+
+class TestTypeEntityAttrs:
+    def test_field_addition(self):
+        assert set(Goodie.attrs().keys()) == {
+            "derived_from", "description", "metadata", "version", "dummy"
+        }
+
+    def test_reference_class_check(self):
+        with pytest.raises(AssertionError):
+            Baddie.attrs()

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/test_integer.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/test_integer.py
@@ -1,0 +1,15 @@
+import pytest
+
+from opera_tosca_parser.error import ParseError
+from opera_tosca_parser.parser.tosca.v_2_0.integer import Integer
+from opera_tosca_parser.parser.yaml.node import Node
+
+
+class TestValidate:
+    def test_with_int_data(self):
+        Integer.validate(Node(1234))
+
+    @pytest.mark.parametrize("data", ["4", (), (1, 2, 3), [], ["a", "b"], {}])
+    def test_with_non_string(self, data):
+        with pytest.raises(ParseError):
+            Integer.validate(Node(data))

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/test_list.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/test_list.py
@@ -1,0 +1,81 @@
+from unittest.mock import Mock
+
+import pytest
+
+from opera_tosca_parser.error import ParseError
+from opera_tosca_parser.parser.tosca.v_2_0.base import Base
+from opera_tosca_parser.parser.tosca.v_2_0.list import List, ListWrapper
+from opera_tosca_parser.parser.yaml.node import Node
+
+
+class TestListParse:
+    @pytest.mark.parametrize("data", [1, 3.4, "", "a", (), {}])
+    def test_non_list_data_is_invalid(self, data):
+        with pytest.raises(ParseError, match="list"):
+            List(Base).parse(Node(data))
+
+    def test_empty_list_is_ok(self):
+        assert List(Base).parse(Node([])).data == []
+
+    def test_list_is_ok(self):
+        obj = List(Base).parse(Node([Node("a"), Node("b")]))
+
+        assert len(obj.data) == 2
+        assert obj.data[0].data == "a"
+        assert obj.data[1].data == "b"
+
+
+class TestListWrapperGetitem:
+    def test_getitem(self):
+        assert ListWrapper(["a", "b"], None)[1] == "b"
+
+    def test_getitem_invalid_index(self):
+        with pytest.raises(IndexError):
+            ListWrapper([], None)[1]
+
+    def test_getitem_invalid_index_type(self):
+        with pytest.raises(TypeError):
+            ListWrapper([], None)["a"]
+
+
+class TestListWrapperIteration:
+    def test_iteration(self):
+        assert tuple(ListWrapper(["a", "b"], None)) == ("a", "b")
+
+
+class TestListWrapperDig:
+    def test_single_level(self):
+        assert ListWrapper(["a", "b"], None).dig(1) == "b"
+
+    def test_multi_level(self):
+        obj = ListWrapper([
+            ListWrapper(["a", "b"], None),
+            ListWrapper(["c", "d"], None),
+        ], None)
+
+        assert obj.dig(0, 0) == "a"
+        assert obj.dig(0, 1) == "b"
+        assert obj.dig(1, 0) == "c"
+        assert obj.dig(1, 1) == "d"
+
+    def test_bad_index(self):
+        assert ListWrapper([], None).dig(1) is None
+
+    def test_bad_index_type(self):
+        assert ListWrapper([], None).dig("a") is None
+
+
+class TestListWrapperVisit:
+    def test_empty_visit(self):
+        ListWrapper([], None).visit("called", "with", keyword="args")
+
+    def test_non_empty_visit(self):
+        obj1 = Base(None, None)
+        obj1.called = Mock()
+        obj2 = Base(None, None)
+        obj2.not_called = Mock()
+
+        ListWrapper([obj1, obj2], None).visit("called", "with", keyword="args")
+
+        obj1.called.assert_called_once_with("with", keyword="args")
+        obj2.not_called.assert_not_called()

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/test_map.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/test_map.py
@@ -1,0 +1,130 @@
+from unittest.mock import Mock
+
+import pytest
+
+from opera_tosca_parser.error import ParseError
+from opera_tosca_parser.parser.tosca.v_2_0.base import Base
+from opera_tosca_parser.parser.tosca.v_2_0.map import Map, MapWrapper, OrderedMap
+from opera_tosca_parser.parser.yaml.node import Node
+
+
+class TestMapWrapperGetitem:
+    def test_lut_access_for_string_key(self):
+        assert MapWrapper({"k": "v"}, None)["k"] == "v"
+
+    def test_test_non_string_key(self):
+        with pytest.raises(KeyError):
+            assert MapWrapper({Base(1, None): "v"}, None)[1]
+
+
+class TestMapWrapperIteration:
+    def test_iteration(self):
+        data = dict(a="b", c="d")
+        assert list(MapWrapper(data, None)) == list(data)
+
+
+class TestMapWrapperValues:
+    def test_values(self):
+        data = dict(a="b", c="d")
+        assert list(MapWrapper(data, None).values()) == list(data.values())
+
+
+class TestMapWrapperKeys:
+    def test_keys(self):
+        data = dict(a="b", c="d")
+        assert list(MapWrapper(data, None).keys()) == list(data.keys())
+
+
+class TestMapWrapperItems:
+    def test_items(self):
+        data = dict(a="b", c="d")
+        assert list(MapWrapper(data, None).items()) == list(data.items())
+
+
+class TestMapWrapperDig:
+    def test_single_level(self):
+        assert MapWrapper({"k": "v"}, None).dig("k") == "v"
+
+    def test_multi_level(self):
+        obj = MapWrapper({
+            "a": MapWrapper({"b": "c"}, None),
+            "d": MapWrapper({"e": "f"}, None),
+        }, None)
+
+        assert obj.dig("a", "b") == "c"
+        assert obj.dig("d", "e") == "f"
+
+    def test_bad_index(self):
+        assert MapWrapper({}, None).dig("a") is None
+
+    def test_bad_index_type(self):
+        assert MapWrapper({}, None).dig(1) is None
+
+
+class TestMapWrapperMerge:
+    def test_merge(self):
+        testmap = MapWrapper({"a": 0}, None)
+        testmap.merge(MapWrapper({"b": 1}, None))
+
+        assert testmap.data == dict(a=0, b=1)
+
+    def test_duplicated_key(self):
+        with pytest.raises(ParseError, match="twice"):
+            MapWrapper({"twice": 0}, None).merge(
+                MapWrapper({"twice": 1}, None),
+            )
+
+
+class TestMapParse:
+    @pytest.mark.parametrize("data", [1, 3.4, "", "a", (), []])
+    def test_non_dict_data_is_invalid(self, data):
+        with pytest.raises(ParseError, match="map"):
+            Map(Base).parse(Node(data))
+
+    def test_empty_dict_is_ok(self):
+        assert Map(Base).parse(Node({})).data == {}
+
+    def test_dict_is_ok(self):
+        obj = Map(Base).parse(Node({
+            Node("a"): Node("b"),
+        }))
+
+        assert len(obj.data) == 1
+        assert obj.data["a"].data == "b"
+
+
+class TestOrderedMapParse:
+    @pytest.mark.parametrize("data", [1, 3.4, "", "a", (), {}])
+    def test_non_list_data_is_invalid(self, data):
+        with pytest.raises(ParseError, match="list"):
+            OrderedMap(Base).parse(Node(data))
+
+    def test_empty_list_is_ok(self):
+        assert OrderedMap(Base).parse(Node([])).data == {}
+
+    def test_dict_is_ok(self):
+        obj = OrderedMap(Base).parse(Node([
+            Node({Node("a"): Node("b")}),
+            Node({Node("c"): Node("d")}),
+        ]))
+        data = [(k, v.data) for k, v in obj.data.items()]
+
+        assert data == [("a", "b"), ("c", "d")]
+
+
+class TestMapWrapperVisit:
+    def test_empty_visit(self):
+        MapWrapper({}, None).visit("called", "with", keyword="args")
+
+    def test_visit(self):
+        obj1 = Base(None, None)
+        obj1.called = Mock()
+        obj2 = Base(None, None)
+        obj2.not_called = Mock()
+
+        MapWrapper({"a": obj1, "b": obj2}, None).visit(
+            "called", "with", keyword="args",
+        )
+
+        obj1.called.assert_called_once_with("with", keyword="args")
+        obj2.not_called.assert_not_called()

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/test_path.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/test_path.py
@@ -1,0 +1,106 @@
+import pathlib
+
+import pytest
+
+from opera_tosca_parser.error import ParseError
+from opera_tosca_parser.parser.tosca.v_2_0.path import Path
+from opera_tosca_parser.parser.yaml.node import Node
+
+
+class TestBuild:
+    def test_build(self):
+        assert isinstance(Path.build(Node("/")).data, pathlib.PurePath)
+
+
+class TestPrefixPath:
+    @pytest.mark.parametrize("input_path,prefix", [
+        ("/a/b", "c"), ("/a", "b"), ("/a", "../.."), ("/c", "."),
+    ])
+    def test_prefix_absolute_path(self, input_path, prefix):
+        path = Path(pathlib.PurePath(input_path), None)
+        path.prefix_path(pathlib.PurePath(prefix))
+
+        assert str(path.data) == input_path
+
+    @pytest.mark.parametrize("input_path,prefix,output", [
+        ("a", "b", "b/a"),
+        ("a", "..", "../a"),
+        ("a", ".", "a"),
+        ("a/b", "c", "c/a/b"),
+        ("a/b", "..", "../a/b"),
+        ("a/b", "c/d", "c/d/a/b"),
+        ("a", "c/d/", "c/d/a"),
+    ])
+    def test_prefix_relative_path(self, input_path, prefix, output):
+        path = Path(pathlib.PurePath(input_path), None)
+        path.prefix_path(pathlib.PurePath(prefix))
+
+        assert str(path.data) == output
+
+
+class TestResolvePath:
+    def test_valid_dir_path(self, tmp_path):
+        rel_path = pathlib.PurePath("some/folder")
+        abs_path = tmp_path / rel_path
+        abs_path.mkdir(parents=True)
+
+        path = Path(rel_path, None)
+        path.resolve_path(tmp_path)
+
+        assert rel_path == path.data
+
+    def test_valid_file_path(self, tmp_path):
+        rel_path = pathlib.PurePath("some/file.txt")
+        abs_path = tmp_path / rel_path
+        abs_path.parent.mkdir(parents=True)
+        abs_path.write_text("sample_text")
+
+        path = Path(rel_path, None)
+        path.resolve_path(tmp_path)
+
+        assert rel_path == path.data
+
+    def test_valid_rel_path_with_dots(self, tmp_path):
+        rel_path = pathlib.PurePath("a/././b/../c/../d")
+        abs_path = (tmp_path / rel_path).resolve()
+        abs_path.mkdir(parents=True)
+
+        path = Path(rel_path, None)
+        path.resolve_path(tmp_path)
+
+        assert pathlib.PurePath("a/d") == path.data
+
+    def test_valid_abs_path_with_dots(self, tmp_path):
+        rel_path = pathlib.PurePath("e/./f/g/h/../i/..")
+        abs_path = (tmp_path / rel_path).resolve()
+        abs_path.mkdir(parents=True)
+
+        path = Path("/" / rel_path, None)
+        path.resolve_path(tmp_path)
+
+        assert pathlib.PurePath("e/f/g") == path.data
+
+    def test_missing_file(self, tmp_path):
+        with pytest.raises(ParseError):
+            Path(pathlib.PurePath("missing"), None).resolve_path(tmp_path)
+
+    def test_symlink(self, tmp_path):
+        file = tmp_path / "file.txt"
+        file.write_text("file")
+        symlink = tmp_path / "symlink"
+        symlink.symlink_to(file)
+
+        with pytest.raises(ParseError):
+            Path(pathlib.PurePath("symlink"), None).resolve_path(tmp_path)
+
+    @pytest.mark.parametrize("path", [
+        "..", "../a", "../../a/b", "a/../..", "a/b/../c/../../..",
+        "/..", "/../a", "/../../a/b", "/a/../..", "/a/b/../c/../../..",
+    ])
+    def test_escape_csar(self, tmp_path, path):
+        with pytest.raises(ParseError):
+            Path(pathlib.PurePath(path), None).resolve_path(tmp_path)
+
+    def test_csar_root(self, tmp_path):
+        with pytest.raises(ParseError):
+            Path(pathlib.PurePath("/c/.."), None).resolve_path(tmp_path)

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/test_reference.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/test_reference.py
@@ -1,0 +1,115 @@
+import pytest
+
+from opera_tosca_parser.error import ParseError
+from opera_tosca_parser.parser.tosca.v_2_0.definitions.service_template import ServiceTemplate
+from opera_tosca_parser.parser.tosca.v_2_0.reference import DataTypeReferenceWrapper, Reference, ReferenceWrapper
+from opera_tosca_parser.parser.tosca.v_2_0.type import Type
+from opera_tosca_parser.parser.yaml.node import Node
+
+
+class TestReferenceWrapperResolveReference:
+    def test_valid_type_reference(self, yaml_ast, tmp_path):
+        service = ServiceTemplate.parse_service_template(yaml_ast(
+            # language=yaml
+            """
+            tosca_definitions_version: tosca_2_0
+            node_types:
+              my.Type:
+                derived_from: tosca.nodes.Root
+            """
+        ), tmp_path, tmp_path, set())[0]
+        ref = ReferenceWrapper("my.Type", None)
+        ref.section_path = ("node_types",)
+
+        assert service.node_types["my.Type"] == ref.resolve_reference(service)
+
+    def test_valid_template_reference(self, yaml_ast, tmp_path):
+        service = ServiceTemplate.parse_service_template(yaml_ast(
+            # language=yaml
+            """
+            tosca_definitions_version: tosca_2_0
+            topology_template:
+              node_templates:
+                my_node:
+                  type: tosca.nodes.Root
+            """
+        ), tmp_path, tmp_path, set())[0]
+        ref = ReferenceWrapper("my_node", None)
+        ref.section_path = ("topology_template", "node_templates")
+
+        target = service.topology_template.node_templates["my_node"]
+        assert target == ref.resolve_reference(service)
+
+    def test_invalid_reference(self, yaml_ast, tmp_path):
+        service = ServiceTemplate.parse_service_template(yaml_ast(
+            # language=yaml
+            """
+            tosca_definitions_version: tosca_2_0
+            node_types:
+              my.Type:
+                derived_from: tosca.nodes.Root
+            """
+        ), tmp_path, tmp_path, set())[0]
+        ref = ReferenceWrapper("INVALID", None)
+        ref.section_path = ("node_types",)
+
+        with pytest.raises(ParseError):
+            ref.resolve_reference(service)
+
+
+class TestDataTypeReferenceWrapperResolveReference:
+    @pytest.mark.parametrize("typ", [
+        "string", "integer", "float", "boolean", "null",
+        "timestamp", "version", "range", "list", "map", "scalar-unit.size",
+        "scalar-unit.time", "scalar-unit.frequency", "scalar-unit.bitrate",
+    ])
+    def test_valid_internal_data_type_reference(self, typ):
+        ref = DataTypeReferenceWrapper(typ, None)
+        ref.section_path = ("data_types",)
+
+        result = ref.resolve_reference(None)
+
+        assert isinstance(result, Type)
+        assert typ == result.data
+
+    def test_valid_user_data_type_reference(self, yaml_ast, tmp_path):
+        service = ServiceTemplate.parse_service_template(yaml_ast(
+            # language=yaml
+            """
+            tosca_definitions_version: tosca_2_0
+            data_types:
+              my.Type:
+                derived_from: float
+            """
+        ), tmp_path, tmp_path, set())[0]
+        ref = DataTypeReferenceWrapper("my.Type", None)
+        ref.section_path = ("data_types",)
+
+        assert service.data_types["my.Type"] == ref.resolve_reference(service)
+
+
+class TestReferenceInit:
+    @pytest.mark.parametrize("path", [
+        ("single",), ("multi", "path"), ("a", "b", "c", "d"),
+    ])
+    def test_valid_init(self, path):
+        assert Reference(*path).section_path == path
+
+    def test_empty_path(self):
+        with pytest.raises(AssertionError):
+            Reference()
+
+    @pytest.mark.parametrize("path", [
+        (1,), (2.3,), (False,), ((),), ([],), ({},), ("a", 1),
+    ])
+    def test_invalid_path_components(self, path):
+        with pytest.raises(AssertionError):
+            Reference(*path)
+
+
+class TestReferenceParse:
+    @pytest.mark.parametrize("path", [
+        ("single",), ("multi", "path"), ("a", "b", "c", "d"),
+    ])
+    def test_parse(self, path):
+        assert Reference(*path).parse(Node("name")).section_path == path

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/test_string.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/test_string.py
@@ -1,0 +1,15 @@
+import pytest
+
+from opera_tosca_parser.error import ParseError
+from opera_tosca_parser.parser.tosca.v_2_0.string import String
+from opera_tosca_parser.parser.yaml.node import Node
+
+
+class TestValidate:
+    def test_with_string_data(self):
+        String.validate(Node("string"))
+
+    @pytest.mark.parametrize("data", [4, (), (1, 2, 3), [], ["a", "b"], {}])
+    def test_with_non_string(self, data):
+        with pytest.raises(ParseError):
+            String.validate(Node(data))

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/test_timestamp.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/test_timestamp.py
@@ -1,0 +1,22 @@
+import pytest
+
+from opera_tosca_parser.error import ParseError
+from opera_tosca_parser.parser.tosca.v_2_0.timestamp import Timestamp
+from opera_tosca_parser.parser.yaml.node import Node
+
+
+class TestValidate:
+    @pytest.mark.parametrize("timestamp", [
+        "2001-12-15T02:59:43.1Z", "2001-12-14t21:59:43.10-05:00", "2001-12-15 2:59:43.10",
+        "2002-12-14", "2022-04-08T21:59:43.10-06:00",
+    ])
+    def test_valid_timestamp(self, timestamp):
+        Timestamp.validate(Node(timestamp))
+
+    @pytest.mark.parametrize("timestamp", [
+        "", " ", "trash", "1", "-50", "01.01", "2001-12-15T02:59:43.1ZNJ", "20020-311-31",
+        "2001-12-15 50:590?43.10", "-100-12-15 2:59:43.10", "2020-1l0-05-15T00:00:00Z"
+    ])
+    def test_invalid_timestamp(self, timestamp):
+        with pytest.raises(ParseError, match="timestamp"):
+            Timestamp.validate(Node(timestamp))

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/test_type.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/test_type.py
@@ -1,0 +1,20 @@
+import pytest
+
+from opera_tosca_parser.parser.tosca.v_2_0.type import Type
+
+
+class TestIsValidInternalType:
+    @pytest.mark.parametrize("typ", [
+        "a", "", "123", "int", "str", "bla", "STRING", "FLOAT", "NULL", "Map",
+        "liST", "Bool", "bool", "BOOL", "Timestamp", "ranGE",
+    ])
+    def test_invalid_types(self, typ):
+        assert Type.is_valid_internal_type(typ) is False
+
+    @pytest.mark.parametrize("typ", [
+        "string", "integer", "float", "boolean", "null",
+        "timestamp", "version", "range", "list", "map", "scalar-unit.size",
+        "scalar-unit.time", "scalar-unit.frequency", "scalar-unit.bitrate",
+    ])
+    def test_valid_built_in_types(self, typ):
+        assert Type.is_valid_internal_type(typ) is True

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/test_url.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/test_url.py
@@ -1,0 +1,3 @@
+class TestUrl:
+    # TODO: Add tests.
+    pass

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/test_version.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/test_version.py
@@ -1,0 +1,22 @@
+import pytest
+
+from opera_tosca_parser.error import ParseError
+from opera_tosca_parser.parser.tosca.v_2_0.version import Version
+from opera_tosca_parser.parser.yaml.node import Node
+
+
+class TestValidate:
+    @pytest.mark.parametrize("version", [
+        "0.0", "0.1", "1.1", "123.456", "1.2.0", "1.2.32", "1.2.3.test",
+        "3.4.5.0rev_a", "6.7.8.a-0", "1.3.6.b-123", "1.2.3.4-5",
+    ])
+    def test_valid_version(self, version):
+        Version.validate(Node(version))
+
+    @pytest.mark.parametrize("version", [
+        "", " ", "garbage", "1", "01.0", "1.02", "1.2.03", "1.2-5", "1-2",
+        "1.2.in-va-lid", "1.2.3-bad", "1.2.3.4-bad",
+    ])
+    def test_invalid_version(self, version):
+        with pytest.raises(ParseError, match="version"):
+            Version.validate(Node(version))

--- a/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/test_void.py
+++ b/tests/unit/opera_tosca_parser/parser/tosca/v_2_0/test_void.py
@@ -1,0 +1,13 @@
+class TestBuild:
+    # TODO: Add tests.
+    pass
+
+
+class TestInit:
+    # TODO: Add tests.
+    pass
+
+
+class TestGetValue:
+    # TODO: Add tests.
+    pass


### PR DESCRIPTION
_This is the **3rd** part of implementing support for  [TOSCA Version 2.0](https://docs.oasis-open.org/tosca/TOSCA/v2.0/TOSCA-v2.0.html) - the incoming version of [OASIS TOSCA](https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=tosca) standard (see #6)._

Within this PR the following changes are made:

- enable parsing coexistence of TOSCA versions 1.3 and 2.0,
- update `opera-tosca-parser parse` CLI command to support parsing 2.0,
- apply minor fixes of unit and integration tests for 1.3,
- supply unit and integration test for 2.0,
- update CI to test against multiple Python versions (`3.8`, `3.9` and `3.10`),
- mention experimental support for TOSCA 2.0 in README.

After these changes the parser is compatible with [TOSCA Version 2.0](https://docs.oasis-open.org/tosca/TOSCA/v2.0/TOSCA-v2.0.html) and after installing (opera-tosca-parser)[https://pypi.org/project/opera-tosca-parser/], the users can use it in one of two ways:

1. as a Python library - call `parse`, `parse_csar`, `parse_service_template` functions that will return `Topology` object,
2. as a CLI - run `opera-tosca-parser parse -i <path-to-inputs> <path-to-service-template-or-csar>` in the console.

Closes #6.

Note: This PR should be merged after #8.